### PR TITLE
lightningclient: add decode payment request function + extra fields

### DIFF
--- a/lightning_client.go
+++ b/lightning_client.go
@@ -1087,6 +1087,11 @@ type Payment struct {
 	// if the payment is settled.
 	Preimage *lntypes.Preimage
 
+	// PaymentRequest is the payment request for this payment. This value
+	// will not be set for keysend payments and for payments that manually
+	// specify their destination and amount.
+	PaymentRequest string
+
 	// Amount is the amount in millisatoshis of the payment.
 	Amount lnwire.MilliSatoshi
 
@@ -1165,6 +1170,7 @@ func (s *lightningClient) ListPayments(ctx context.Context,
 
 		pmt := Payment{
 			Hash:           hash,
+			PaymentRequest: payment.PaymentRequest,
 			Status:         status,
 			Htlcs:          payment.Htlcs,
 			Amount:         lnwire.MilliSatoshi(payment.ValueMsat),

--- a/lightning_client.go
+++ b/lightning_client.go
@@ -44,8 +44,12 @@ type LightningClient interface {
 	LookupInvoice(ctx context.Context, hash lntypes.Hash) (*Invoice, error)
 
 	// ListTransactions returns all known transactions of the backing lnd
-	// node.
-	ListTransactions(ctx context.Context) ([]Transaction, error)
+	// node. It takes a start and end block height which can be used to
+	// limit the block range that we query over. These values can be left
+	// as zero to include all blocks. To include unconfirmed transactions
+	// in the query, endHeight must be set to -1.
+	ListTransactions(ctx context.Context, startHeight,
+		endHeight int32) ([]Transaction, error)
 
 	// ListChannels retrieves all channels of the backing lnd node.
 	ListChannels(ctx context.Context) ([]ChannelInfo, error)
@@ -704,12 +708,18 @@ func unmarshalInvoice(resp *lnrpc.Invoice) (*Invoice, error) {
 }
 
 // ListTransactions returns all known transactions of the backing lnd node.
-func (s *lightningClient) ListTransactions(ctx context.Context) ([]Transaction, error) {
+func (s *lightningClient) ListTransactions(ctx context.Context, startHeight,
+	endHeight int32) ([]Transaction, error) {
+
 	rpcCtx, cancel := context.WithTimeout(ctx, rpcTimeout)
 	defer cancel()
 
 	rpcCtx = s.adminMac.WithMacaroonAuth(rpcCtx)
-	rpcIn := &lnrpc.GetTransactionsRequest{}
+	rpcIn := &lnrpc.GetTransactionsRequest{
+		StartHeight: startHeight,
+		EndHeight:   endHeight,
+	}
+
 	resp, err := s.client.GetTransactions(rpcCtx, rpcIn)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Combining a few unrelated changes:
- Add start/end height to ListTransactions
- Add DecodePaymentRequest to lightning client
- Add payment request field to payment struct

Tested this locally with Faraday, which needs the new endpoint.