### PR TITLE
lndclient: add invoice htlcs and close height

### DIFF
--- a/lightning_client.go
+++ b/lightning_client.go
@@ -108,7 +108,8 @@ type LightningClient interface {
 
 	// CloseChannel closes the channel provided.
 	CloseChannel(ctx context.Context, channel *wire.OutPoint,
-		force bool) (chan CloseChannelUpdate, chan error, error)
+		force bool, confTarget int32) (chan CloseChannelUpdate,
+		chan error, error)
 
 	// UpdateChanPolicy updates the channel policy for the passed chanPoint.
 	// If the chanPoint is nil, then the policy is applied for all existing
@@ -1910,8 +1911,8 @@ func (p *ChannelClosedUpdate) CloseTxid() chainhash.Hash {
 // sending an EOF), we close the updates and error channel to signal that there
 // are no more updates to be sent.
 func (s *lightningClient) CloseChannel(ctx context.Context,
-	channel *wire.OutPoint, force bool) (chan CloseChannelUpdate,
-	chan error, error) {
+	channel *wire.OutPoint, force bool,
+	confTarget int32) (chan CloseChannelUpdate, chan error, error) {
 
 	rpcCtx := s.adminMac.WithMacaroonAuth(ctx)
 
@@ -1922,7 +1923,8 @@ func (s *lightningClient) CloseChannel(ctx context.Context,
 			},
 			OutputIndex: channel.Index,
 		},
-		Force: force,
+		TargetConf: confTarget,
+		Force:      force,
 	})
 	if err != nil {
 		return nil, nil, err

--- a/lightning_client.go
+++ b/lightning_client.go
@@ -248,6 +248,9 @@ type ClosedChannel struct {
 	// CloseType is the type of channel closure.
 	CloseType CloseType
 
+	// CloseHeight is the height that the channel was closed at.
+	CloseHeight uint32
+
 	// OpenInitiator is true if we opened the channel. This value is not
 	// always available (older channels do not have it).
 	OpenInitiator Initiator
@@ -1139,6 +1142,7 @@ func getClosedChannel(closeSummary *lnrpc.ChannelCloseSummary) (
 		ChannelID:      closeSummary.ChanId,
 		ClosingTxHash:  closeSummary.ClosingTxHash,
 		CloseType:      closeType,
+		CloseHeight:    closeSummary.CloseHeight,
 		OpenInitiator:  openInitiator,
 		CloseInitiator: closeInitiator,
 		PubKeyBytes:    remote,

--- a/lightning_client.go
+++ b/lightning_client.go
@@ -738,6 +738,12 @@ type Invoice struct {
 
 	// Htlcs is the set of htlcs that the invoice was settled with.
 	Htlcs []InvoiceHtlc
+
+	// AddIndex is the index at which the invoice was added.
+	AddIndex uint64
+
+	// SettleIndex is the index at which the invoice was settled.
+	SettleIndex uint64
 }
 
 // InvoiceHtlc represents a htlc that was used to pay an invoice.
@@ -802,6 +808,8 @@ func unmarshalInvoice(resp *lnrpc.Invoice) (*Invoice, error) {
 		CreationDate:   time.Unix(resp.CreationDate, 0),
 		IsKeysend:      resp.IsKeysend,
 		Htlcs:          make([]InvoiceHtlc, len(resp.Htlcs)),
+		AddIndex:       resp.AddIndex,
+		SettleIndex:    resp.SettleIndex,
 	}
 
 	for i, htlc := range resp.Htlcs {


### PR DESCRIPTION
This PR adds a few fields to our existing response:
- Add htlcs to our invoices
- Add close height to close summary
- Add invoice add and settle index to invoices

All of these changes are in the existing lnd 0.11.1 release, so can be merged. 