### PR TITLE
lnd 0.11.1: allow custom macaroon to be used instead of requiring all subserver macaroons

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,3 @@
+#### Pull Request Checklist
+- [ ] Update `macaroon_recipes.go` if your PR adds a new method that is called
+  differently than the RPC method it invokes.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,4 +44,56 @@ jobs:
           go-version: '~${{ env.GO_VERSION }}'
 
       - name: compile
-        run: go build
+        run: make build
+
+  lint:
+    name: lint package
+    runs-on: ubuntu-latest
+    steps:
+      - name: git checkout
+        uses: actions/checkout@v2
+
+      - name: go cache
+        uses: actions/cache@v1
+        with:
+          path: /home/runner/work/go
+          key: lnd-${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ github.job }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            lnd-${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ github.job }}-${{ hashFiles('**/go.sum') }}
+            lnd-${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ github.job }}-
+            lnd-${{ runner.os }}-go-${{ env.GO_VERSION }}-
+            lnd-${{ runner.os }}-go-
+
+      - name: setup go ${{ env.GO_VERSION }}
+        uses: actions/setup-go@v2
+        with:
+          go-version: '~${{ env.GO_VERSION }}'
+
+      - name: compile
+        run: make lint
+
+  race:
+    name: unit race test package
+    runs-on: ubuntu-latest
+    steps:
+      - name: git checkout
+        uses: actions/checkout@v2
+
+      - name: go cache
+        uses: actions/cache@v1
+        with:
+          path: /home/runner/work/go
+          key: lnd-${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ github.job }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            lnd-${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ github.job }}-${{ hashFiles('**/go.sum') }}
+            lnd-${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ github.job }}-
+            lnd-${{ runner.os }}-go-${{ env.GO_VERSION }}-
+            lnd-${{ runner.os }}-go-
+
+      - name: setup go ${{ env.GO_VERSION }}
+        uses: actions/setup-go@v2
+        with:
+          go-version: '~${{ env.GO_VERSION }}'
+
+      - name: compile
+        run: make unit-race

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,69 @@
+PKG := github.com/lightninglabs/lndclient
+
+LINT_PKG := github.com/golangci/golangci-lint/cmd/golangci-lint
+
+GO_BIN := ${GOPATH}/bin
+LINT_BIN := $(GO_BIN)/golangci-lint
+
+LINT_COMMIT := v1.18.0
+
+DEPGET := cd /tmp && GO111MODULE=on go get -v
+GOBUILD := GO111MODULE=on go build -v
+GOTEST := GO111MODULE=on go test -v
+
+LINT = $(LINT_BIN) run -v
+GOFILES = $(shell find . -type f -name '*.go')
+
+GREEN := "\\033[0;32m"
+NC := "\\033[0m"
+define print
+	echo $(GREEN)$1$(NC)
+endef
+
+default: build
+
+# ============
+# DEPENDENCIES
+# ============
+$(LINT_BIN):
+	@$(call print, "Fetching linter")
+	$(DEPGET) $(LINT_PKG)@$(LINT_COMMIT)
+
+# ============
+# INSTALLATION
+# ============
+
+build:
+	@$(call print, "Building lndclient.")
+	$(GOBUILD) $(PKG)
+
+# =======
+# TESTING
+# =======
+
+unit:
+	@$(call print, "Running unit tests.")
+	$(GOTEST) ./...
+
+unit-race:
+	@$(call print, "Running unit race tests.")
+	env CGO_ENABLED=1 GORACE="history_size=7 halt_on_errors=1" $(GOTEST) ./...
+
+# =========
+# UTILITIES
+# =========
+
+fmt:
+	@$(call print, "Formatting source.")
+	gofmt -l -w -s $(GOFILES)
+
+lint: $(LINT_BIN)
+	@$(call print, "Linting source.")
+	$(LINT)
+
+.PHONY: default \
+	build \
+	unit \
+	unit-race \
+	fmt \
+	lint

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/btcsuite/btcutil v1.0.2
 	github.com/btcsuite/btcwallet/wtxmgr v1.2.0
 	github.com/lightningnetwork/lnd v0.11.1-beta
+	github.com/stretchr/testify v1.5.1
 	google.golang.org/grpc v1.24.0
 	gopkg.in/macaroon.v2 v2.1.0
 )

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f
 	github.com/btcsuite/btcutil v1.0.2
 	github.com/btcsuite/btcwallet/wtxmgr v1.2.0
-	github.com/lightningnetwork/lnd v0.11.0-beta
+	github.com/lightningnetwork/lnd v0.11.1-beta
 	google.golang.org/grpc v1.24.0
 	gopkg.in/macaroon.v2 v2.1.0
 )

--- a/go.sum
+++ b/go.sum
@@ -33,10 +33,10 @@ github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f/go.mod h1:TdznJufo
 github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d/go.mod h1:+5NJ2+qvTyV9exUAL/rxXi3DcLg2Ts+ymUAY5y4NvMg=
 github.com/btcsuite/btcutil v1.0.2 h1:9iZ1Terx9fMIOtq1VrwdqfsATL9MC2l8ZrUY6YZ2uts=
 github.com/btcsuite/btcutil v1.0.2/go.mod h1:j9HUFwoQRsZL3V4n+qG+CUnEGHOarIxfC3Le2Yhbcts=
-github.com/btcsuite/btcutil/psbt v1.0.2 h1:gCVY3KxdoEVU7Q6TjusPO+GANIwVgr9yTLqM+a6CZr8=
-github.com/btcsuite/btcutil/psbt v1.0.2/go.mod h1:LVveMu4VaNSkIRTZu2+ut0HDBRuYjqGocxDMNS1KuGQ=
-github.com/btcsuite/btcwallet v0.11.1-0.20200814001439-1d31f4ea6fc5 h1:1We7EuizBnX/17Q6O2dkeToyehxzUHo62Wv1c0ncr7c=
-github.com/btcsuite/btcwallet v0.11.1-0.20200814001439-1d31f4ea6fc5/go.mod h1:YkEbJaCyN6yncq5gEp2xG0OKDwus2QxGCEXTNF27w5I=
+github.com/btcsuite/btcutil/psbt v1.0.3-0.20200826194809-5f93e33af2b0 h1:3Zumkyl6PWyHuVJ04me0xeD9CnPOhNgeGpapFbzy7O4=
+github.com/btcsuite/btcutil/psbt v1.0.3-0.20200826194809-5f93e33af2b0/go.mod h1:LVveMu4VaNSkIRTZu2+ut0HDBRuYjqGocxDMNS1KuGQ=
+github.com/btcsuite/btcwallet v0.11.1-0.20200904022754-2c5947a45222 h1:rh1FQAhh+BeR29twIFDM0RLOFpDK62tsABtUkWctTXw=
+github.com/btcsuite/btcwallet v0.11.1-0.20200904022754-2c5947a45222/go.mod h1:owv9oZqM0HnUW+ByF7VqOgfs2eb0ooiePW/+Tl/i/Nk=
 github.com/btcsuite/btcwallet/wallet/txauthor v1.0.0 h1:KGHMW5sd7yDdDMkCZ/JpP0KltolFsQcB973brBnfj4c=
 github.com/btcsuite/btcwallet/wallet/txauthor v1.0.0/go.mod h1:VufDts7bd/zs3GV13f/lXc/0lXrPnvxD/NvmpG/FEKU=
 github.com/btcsuite/btcwallet/wallet/txrules v1.0.0 h1:2VsfS0sBedcM5KmDzRMT3+b6xobqWveZGvjb+jFez5w=
@@ -181,8 +181,8 @@ github.com/lightninglabs/neutrino v0.11.1-0.20200316235139-bffc52e8f200/go.mod h
 github.com/lightninglabs/protobuf-hex-display v1.3.3-0.20191212020323-b444784ce75d/go.mod h1:KDb67YMzoh4eudnzClmvs2FbiLG9vxISmLApUkCa4uI=
 github.com/lightningnetwork/lightning-onion v1.0.2-0.20200501022730-3c8c8d0b89ea h1:oCj48NQ8u7Vz+MmzHqt0db6mxcFZo3Ho7M5gCJauY/k=
 github.com/lightningnetwork/lightning-onion v1.0.2-0.20200501022730-3c8c8d0b89ea/go.mod h1:rigfi6Af/KqsF7Za0hOgcyq2PNH4AN70AaMRxcJkff4=
-github.com/lightningnetwork/lnd v0.11.0-beta h1:pUAT7FMHqS+iarNxyRtgj96XKCGAWwmb6ZdiUBy78ts=
-github.com/lightningnetwork/lnd v0.11.0-beta/go.mod h1:CzArvT7NFDLhVyW06+NJWSuWFmE6Ea+AjjA3txUBqTM=
+github.com/lightningnetwork/lnd v0.11.1-beta h1:SYpb8s+to3rAPTd4fWqkhTEO2QpnGJ3MJYb7m09fPjE=
+github.com/lightningnetwork/lnd v0.11.1-beta/go.mod h1:PGIgxy8aH70Li33YVYkHSaCM8m8LjEevk5h1Dpldrr4=
 github.com/lightningnetwork/lnd/cert v1.0.2 h1:g2rEu+sM2Uyz0bpfuvwri/ks6R/26H5iY1NcGbpDJ+c=
 github.com/lightningnetwork/lnd/cert v1.0.2/go.mod h1:fmtemlSMf5t4hsQmcprSoOykypAPp+9c+0d0iqTScMo=
 github.com/lightningnetwork/lnd/clock v1.0.1 h1:QQod8+m3KgqHdvVMV+2DRNNZS1GRFir8mHZYA+Z2hFo=

--- a/lightning_client.go
+++ b/lightning_client.go
@@ -154,6 +154,11 @@ type LightningClient interface {
 
 	// NetworkInfo returns stats regarding our view of the network.
 	NetworkInfo(ctx context.Context) (*NetworkInfo, error)
+
+	// ListPermissions returns a list of all RPC method URIs and the
+	// macaroon permissions that are required to access them.
+	ListPermissions(ctx context.Context) (map[string][]MacaroonPermission,
+		error)
 }
 
 // Info contains info about the connected lnd node.
@@ -2702,4 +2707,50 @@ func (s *lightningClient) NetworkInfo(ctx context.Context) (*NetworkInfo,
 		MedianChannelSize:    btcutil.Amount(resp.MedianChannelSizeSat),
 		NumZombieChans:       resp.NumZombieChans,
 	}, nil
+}
+
+// MacaroonPermission is a struct that holds a permission entry, consisting of
+// an entity and an action.
+type MacaroonPermission struct {
+	// Entity is the entity a permission grants access to.
+	Entity string
+
+	// Action is the action that is granted by a permission.
+	Action string
+}
+
+// String returns the human readable representation of a permission.
+func (p *MacaroonPermission) String() string {
+	return fmt.Sprintf("%s:%s", p.Entity, p.Action)
+}
+
+// ListPermissions returns a list of all RPC method URIs and the macaroon
+// permissions that are required to access them.
+func (s *lightningClient) ListPermissions(
+	ctx context.Context) (map[string][]MacaroonPermission, error) {
+
+	rpcCtx, cancel := context.WithTimeout(ctx, rpcTimeout)
+	defer cancel()
+
+	rpcCtx = s.adminMac.WithMacaroonAuth(rpcCtx)
+	perms, err := s.client.ListPermissions(
+		rpcCtx, &lnrpc.ListPermissionsRequest{},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make(map[string][]MacaroonPermission)
+	for methodURI, list := range perms.MethodPermissions {
+		permissions := list.Permissions
+		result[methodURI] = make([]MacaroonPermission, len(permissions))
+		for idx, entry := range permissions {
+			result[methodURI][idx] = MacaroonPermission{
+				Entity: entry.Entity,
+				Action: entry.Action,
+			}
+		}
+	}
+
+	return result, nil
 }

--- a/lnd_services.go
+++ b/lnd_services.go
@@ -32,12 +32,10 @@ var (
 	// tags can be adjusted accordingly. This default will be used as a fall
 	// back version if none is specified in the configuration.
 	minimalCompatibleVersion = &verrpc.Version{
-		AppMajor: 0,
-		AppMinor: 11,
-		AppPatch: 0,
-		BuildTags: []string{
-			"signrpc", "walletrpc", "chainrpc", "invoicesrpc",
-		},
+		AppMajor:  0,
+		AppMinor:  11,
+		AppPatch:  0,
+		BuildTags: DefaultBuildTags,
 	}
 
 	// ErrVersionCheckNotImplemented is the error that is returned if the
@@ -54,6 +52,12 @@ var (
 	// connected lnd instance does not have all built tags activated that
 	// are required.
 	ErrBuildTagsMissing = errors.New("build tags missing")
+
+	// DefaultBuildTags is the list of all subserver build tags that are
+	// required for lndclient to work.
+	DefaultBuildTags = []string{
+		"signrpc", "walletrpc", "chainrpc", "invoicesrpc",
+	}
 )
 
 // LndServicesConfig holds all configuration settings that are needed to connect

--- a/lnd_services.go
+++ b/lnd_services.go
@@ -67,7 +67,12 @@ type LndServicesConfig struct {
 	Network Network
 
 	// MacaroonDir is the directory where all lnd macaroons can be found.
+	// Either this or CustomMacaroonPath can be specified but not both.
 	MacaroonDir string
+
+	// CustomMacaroonPath is the full path to a custom macaroon file. Either
+	// this or MacaroonDir can be specified but not both.
+	CustomMacaroonPath string
 
 	// TLSPath is the path to lnd's TLS certificate file.
 	TLSPath string
@@ -138,6 +143,14 @@ func NewLndServices(cfg *LndServicesConfig) (*GrpcLndServices, error) {
 		cfg.CheckVersion = minimalCompatibleVersion
 	}
 
+	// We don't allow setting both the macaroon directory and the custom
+	// macaroon path. If both are empty, that's fine, the default behavior
+	// is to use lnd's default directory to try to locate the macaroons.
+	if cfg.MacaroonDir != "" && cfg.CustomMacaroonPath != "" {
+		return nil, fmt.Errorf("must set either MacaroonDir or " +
+			"CustomMacaroonPath but not both")
+	}
+
 	// Based on the network, if the macaroon directory isn't set, then
 	// we'll use the expected default locations.
 	macaroonDir := cfg.MacaroonDir
@@ -193,8 +206,8 @@ func NewLndServices(cfg *LndServicesConfig) (*GrpcLndServices, error) {
 	// macaroon. We don't use the pouch yet because if not all subservers
 	// are enabled, then not all macaroons might be there and the user would
 	// get a more cryptic error message.
-	readonlyMac, err := newSerializedMacaroon(
-		filepath.Join(macaroonDir, defaultReadonlyFilename),
+	readonlyMac, err := loadMacaroon(
+		macaroonDir, defaultReadonlyFilename, cfg.CustomMacaroonPath,
 	)
 	if err != nil {
 		return nil, err
@@ -208,7 +221,7 @@ func NewLndServices(cfg *LndServicesConfig) (*GrpcLndServices, error) {
 
 	// Now that we've ensured our macaroon directory is set properly, we
 	// can retrieve our full macaroon pouch from the directory.
-	macaroons, err := newMacaroonPouch(macaroonDir)
+	macaroons, err := newMacaroonPouch(macaroonDir, cfg.CustomMacaroonPath)
 	if err != nil {
 		return nil, fmt.Errorf("unable to obtain macaroons: %v", err)
 	}

--- a/lnd_services.go
+++ b/lnd_services.go
@@ -34,7 +34,7 @@ var (
 	minimalCompatibleVersion = &verrpc.Version{
 		AppMajor:  0,
 		AppMinor:  11,
-		AppPatch:  0,
+		AppPatch:  1,
 		BuildTags: DefaultBuildTags,
 	}
 

--- a/macaroon_recipes.go
+++ b/macaroon_recipes.go
@@ -1,0 +1,113 @@
+package lndclient
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+var (
+	// supportedSubservers is a map of all RPC (sub)server names that are
+	// supported by the lndclient library and their implementing interface
+	// type. We use reflection to look up the methods implemented on those
+	// interfaces to find out which permissions are needed for them.
+	supportedSubservers = map[string]interface{}{
+		"lnrpc":       (*LightningClient)(nil),
+		"chainrpc":    (*ChainNotifierClient)(nil),
+		"invoicesrpc": (*InvoicesClient)(nil),
+		"routerrpc":   (*RouterClient)(nil),
+		"signrpc":     (*SignerClient)(nil),
+		"verrpc":      (*VersionerClient)(nil),
+		"walletrpc":   (*WalletKitClient)(nil),
+	}
+
+	// renames is a map of renamed RPC method names. The key is the name as
+	// implemented in lndclient and the value is the original name of the
+	// RPC method defined in the proto.
+	renames = map[string]string{
+		"ChannelBackup":          "ExportChannelBackup",
+		"ChannelBackups":         "ExportAllChannelBackups",
+		"ConfirmedWalletBalance": "WalletBalance",
+		"Connect":                "ConnectPeer",
+		"DecodePaymentRequest":   "DecodePayReq",
+		"EstimateFeeToP2WSH":     "EstimateFee",
+		"ListTransactions":       "GetTransactions",
+		"PayInvoice":             "SendPaymentSync",
+		"UpdateChanPolicy":       "UpdateChannelPolicy",
+		"NetworkInfo":            "GetNetworkInfo",
+	}
+)
+
+// MacaroonRecipe returns a list of macaroon permissions that is required to use
+// the full feature set of the given list of RPC package names.
+func MacaroonRecipe(c LightningClient, packages []string) ([]MacaroonPermission,
+	error) {
+
+	// Get the full map of RPC URIs and the required permissions from the
+	// backing lnd instance.
+	allPermissions, err := c.ListPermissions(context.Background())
+	if err != nil {
+		return nil, err
+	}
+
+	uniquePermissions := make(map[string]map[string]struct{})
+	for _, pkg := range packages {
+		// Get the typed pointer from our map of supported interfaces.
+		ifacePtr, ok := supportedSubservers[pkg]
+		if !ok {
+			return nil, fmt.Errorf("unknown subserver %s", pkg)
+		}
+
+		// From the pointer type we can find out the interface, its name
+		// and what methods it declares.
+		ifaceType := reflect.TypeOf(ifacePtr).Elem()
+		serverName := strings.ReplaceAll(ifaceType.Name(), "Client", "")
+		for i := 0; i < ifaceType.NumMethod(); i++ {
+			// The methods in lndclient might be called slightly
+			// differently. Rename according to our rename mapping
+			// table.
+			methodName := ifaceType.Method(i).Name
+			rename, ok := renames[methodName]
+			if ok {
+				methodName = rename
+			}
+
+			// The full RPC URI is /package.Service/MethodName.
+			rpcURI := fmt.Sprintf(
+				"/%s.%s/%s", pkg, serverName, methodName,
+			)
+
+			requiredPermissions, ok := allPermissions[rpcURI]
+			if !ok {
+				return nil, fmt.Errorf("URI %s not found in "+
+					"permission list", rpcURI)
+			}
+
+			// Add these permissions to the map we use to
+			// de-duplicate the values.
+			for _, perm := range requiredPermissions {
+				actions, ok := uniquePermissions[perm.Entity]
+				if !ok {
+					actions = make(map[string]struct{})
+					uniquePermissions[perm.Entity] = actions
+				}
+				actions[perm.Action] = struct{}{}
+			}
+		}
+	}
+
+	// Turn the de-duplicated map back into a slice of permission entries.
+	var requiredPermissions []MacaroonPermission
+	for entity, actions := range uniquePermissions {
+		for action := range actions {
+			requiredPermissions = append(
+				requiredPermissions, MacaroonPermission{
+					Entity: entity,
+					Action: action,
+				},
+			)
+		}
+	}
+	return requiredPermissions, nil
+}

--- a/macaroon_recipes_test.go
+++ b/macaroon_recipes_test.go
@@ -1,0 +1,87 @@
+package lndclient_test
+
+import (
+	"context"
+	"encoding/json"
+	"io/ioutil"
+	"testing"
+
+	"github.com/lightninglabs/lndclient"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	expectedPermissions = map[string]int{
+		"lnrpc":       9,
+		"chainrpc":    1,
+		"invoicesrpc": 2,
+		"routerrpc":   2,
+		"signrpc":     2,
+		"verrpc":      1,
+		"walletrpc":   3,
+	}
+)
+
+type permissionJsonData struct {
+	Permissions map[string]struct {
+		Permissions []struct {
+			Entity string `json:"entity"`
+			Action string `json:"action"`
+		} `json:"permissions"`
+	} `json:"method_permissions"`
+}
+
+type lightningMock struct {
+	lndclient.LightningClient
+
+	mockPermissions map[string][]lndclient.MacaroonPermission
+}
+
+func (m *lightningMock) ListPermissions(
+	_ context.Context) (map[string][]lndclient.MacaroonPermission, error) {
+
+	return m.mockPermissions, nil
+}
+
+// TestMacaroonRecipe makes sure the macaroon recipe for all supported packages
+// can be generated.
+func TestMacaroonRecipe(t *testing.T) {
+	// Load our static permissions exported from lnd by calling
+	// `lncli listpermissions > permissions.json`.
+	content, err := ioutil.ReadFile("testdata/permissions.json")
+	require.NoError(t, err)
+
+	data := &permissionJsonData{}
+	err = json.Unmarshal(content, data)
+	require.NoError(t, err)
+
+	mockPermissions := make(map[string][]lndclient.MacaroonPermission)
+	for uri, perms := range data.Permissions {
+		mockPermissions[uri] = make(
+			[]lndclient.MacaroonPermission, len(perms.Permissions),
+		)
+		for idx, perm := range perms.Permissions {
+			mockPermissions[uri][idx] = lndclient.MacaroonPermission{
+				Entity: perm.Entity,
+				Action: perm.Action,
+			}
+		}
+	}
+	clientMock := &lightningMock{
+		mockPermissions: mockPermissions,
+	}
+
+	// Run the test for all supported RPC packages.
+	for pkg, numPermissions := range expectedPermissions {
+		pkg, numPermissions := pkg, numPermissions
+		t.Run(pkg, func(t *testing.T) {
+			t.Parallel()
+
+			requiredPermissions, err := lndclient.MacaroonRecipe(
+				clientMock, []string{pkg},
+			)
+			require.NoError(t, err)
+			require.Len(t, requiredPermissions, numPermissions)
+		})
+	}
+}

--- a/testdata/permissions.json
+++ b/testdata/permissions.json
@@ -1,0 +1,920 @@
+{
+    "method_permissions": {
+        "/autopilotrpc.Autopilot/ModifyStatus": {
+            "permissions": [
+                {
+                    "entity": "onchain",
+                    "action": "write"
+                },
+                {
+                    "entity": "offchain",
+                    "action": "write"
+                }
+            ]
+        },
+        "/autopilotrpc.Autopilot/QueryScores": {
+            "permissions": [
+                {
+                    "entity": "info",
+                    "action": "read"
+                }
+            ]
+        },
+        "/autopilotrpc.Autopilot/SetScores": {
+            "permissions": [
+                {
+                    "entity": "onchain",
+                    "action": "write"
+                },
+                {
+                    "entity": "offchain",
+                    "action": "write"
+                }
+            ]
+        },
+        "/autopilotrpc.Autopilot/Status": {
+            "permissions": [
+                {
+                    "entity": "info",
+                    "action": "read"
+                }
+            ]
+        },
+        "/chainrpc.ChainNotifier/RegisterBlockEpochNtfn": {
+            "permissions": [
+                {
+                    "entity": "onchain",
+                    "action": "read"
+                }
+            ]
+        },
+        "/chainrpc.ChainNotifier/RegisterConfirmationsNtfn": {
+            "permissions": [
+                {
+                    "entity": "onchain",
+                    "action": "read"
+                }
+            ]
+        },
+        "/chainrpc.ChainNotifier/RegisterSpendNtfn": {
+            "permissions": [
+                {
+                    "entity": "onchain",
+                    "action": "read"
+                }
+            ]
+        },
+        "/invoicesrpc.Invoices/AddHoldInvoice": {
+            "permissions": [
+                {
+                    "entity": "invoices",
+                    "action": "write"
+                }
+            ]
+        },
+        "/invoicesrpc.Invoices/CancelInvoice": {
+            "permissions": [
+                {
+                    "entity": "invoices",
+                    "action": "write"
+                }
+            ]
+        },
+        "/invoicesrpc.Invoices/SettleInvoice": {
+            "permissions": [
+                {
+                    "entity": "invoices",
+                    "action": "write"
+                }
+            ]
+        },
+        "/invoicesrpc.Invoices/SubscribeSingleInvoice": {
+            "permissions": [
+                {
+                    "entity": "invoices",
+                    "action": "read"
+                }
+            ]
+        },
+        "/lnrpc.Lightning/AbandonChannel": {
+            "permissions": [
+                {
+                    "entity": "offchain",
+                    "action": "write"
+                }
+            ]
+        },
+        "/lnrpc.Lightning/AddInvoice": {
+            "permissions": [
+                {
+                    "entity": "invoices",
+                    "action": "write"
+                }
+            ]
+        },
+        "/lnrpc.Lightning/BakeMacaroon": {
+            "permissions": [
+                {
+                    "entity": "macaroon",
+                    "action": "generate"
+                }
+            ]
+        },
+        "/lnrpc.Lightning/ChannelAcceptor": {
+            "permissions": [
+                {
+                    "entity": "onchain",
+                    "action": "write"
+                },
+                {
+                    "entity": "offchain",
+                    "action": "write"
+                }
+            ]
+        },
+        "/lnrpc.Lightning/ChannelBalance": {
+            "permissions": [
+                {
+                    "entity": "offchain",
+                    "action": "read"
+                }
+            ]
+        },
+        "/lnrpc.Lightning/CloseChannel": {
+            "permissions": [
+                {
+                    "entity": "onchain",
+                    "action": "write"
+                },
+                {
+                    "entity": "offchain",
+                    "action": "write"
+                }
+            ]
+        },
+        "/lnrpc.Lightning/ClosedChannels": {
+            "permissions": [
+                {
+                    "entity": "offchain",
+                    "action": "read"
+                }
+            ]
+        },
+        "/lnrpc.Lightning/ConnectPeer": {
+            "permissions": [
+                {
+                    "entity": "peers",
+                    "action": "write"
+                }
+            ]
+        },
+        "/lnrpc.Lightning/DebugLevel": {
+            "permissions": [
+                {
+                    "entity": "info",
+                    "action": "write"
+                }
+            ]
+        },
+        "/lnrpc.Lightning/DecodePayReq": {
+            "permissions": [
+                {
+                    "entity": "offchain",
+                    "action": "read"
+                }
+            ]
+        },
+        "/lnrpc.Lightning/DeleteAllPayments": {
+            "permissions": [
+                {
+                    "entity": "offchain",
+                    "action": "write"
+                }
+            ]
+        },
+        "/lnrpc.Lightning/DeleteMacaroonID": {
+            "permissions": [
+                {
+                    "entity": "macaroon",
+                    "action": "write"
+                }
+            ]
+        },
+        "/lnrpc.Lightning/DescribeGraph": {
+            "permissions": [
+                {
+                    "entity": "info",
+                    "action": "read"
+                }
+            ]
+        },
+        "/lnrpc.Lightning/DisconnectPeer": {
+            "permissions": [
+                {
+                    "entity": "peers",
+                    "action": "write"
+                }
+            ]
+        },
+        "/lnrpc.Lightning/EstimateFee": {
+            "permissions": [
+                {
+                    "entity": "onchain",
+                    "action": "read"
+                }
+            ]
+        },
+        "/lnrpc.Lightning/ExportAllChannelBackups": {
+            "permissions": [
+                {
+                    "entity": "offchain",
+                    "action": "read"
+                }
+            ]
+        },
+        "/lnrpc.Lightning/ExportChannelBackup": {
+            "permissions": [
+                {
+                    "entity": "offchain",
+                    "action": "read"
+                }
+            ]
+        },
+        "/lnrpc.Lightning/FeeReport": {
+            "permissions": [
+                {
+                    "entity": "offchain",
+                    "action": "read"
+                }
+            ]
+        },
+        "/lnrpc.Lightning/ForwardingHistory": {
+            "permissions": [
+                {
+                    "entity": "offchain",
+                    "action": "read"
+                }
+            ]
+        },
+        "/lnrpc.Lightning/FundingStateStep": {
+            "permissions": [
+                {
+                    "entity": "onchain",
+                    "action": "write"
+                },
+                {
+                    "entity": "offchain",
+                    "action": "write"
+                }
+            ]
+        },
+        "/lnrpc.Lightning/GetChanInfo": {
+            "permissions": [
+                {
+                    "entity": "info",
+                    "action": "read"
+                }
+            ]
+        },
+        "/lnrpc.Lightning/GetInfo": {
+            "permissions": [
+                {
+                    "entity": "info",
+                    "action": "read"
+                }
+            ]
+        },
+        "/lnrpc.Lightning/GetNetworkInfo": {
+            "permissions": [
+                {
+                    "entity": "info",
+                    "action": "read"
+                }
+            ]
+        },
+        "/lnrpc.Lightning/GetNodeInfo": {
+            "permissions": [
+                {
+                    "entity": "info",
+                    "action": "read"
+                }
+            ]
+        },
+        "/lnrpc.Lightning/GetNodeMetrics": {
+            "permissions": [
+                {
+                    "entity": "info",
+                    "action": "read"
+                }
+            ]
+        },
+        "/lnrpc.Lightning/GetRecoveryInfo": {
+            "permissions": [
+                {
+                    "entity": "info",
+                    "action": "read"
+                }
+            ]
+        },
+        "/lnrpc.Lightning/GetTransactions": {
+            "permissions": [
+                {
+                    "entity": "onchain",
+                    "action": "read"
+                }
+            ]
+        },
+        "/lnrpc.Lightning/ListChannels": {
+            "permissions": [
+                {
+                    "entity": "offchain",
+                    "action": "read"
+                }
+            ]
+        },
+        "/lnrpc.Lightning/ListInvoices": {
+            "permissions": [
+                {
+                    "entity": "invoices",
+                    "action": "read"
+                }
+            ]
+        },
+        "/lnrpc.Lightning/ListMacaroonIDs": {
+            "permissions": [
+                {
+                    "entity": "macaroon",
+                    "action": "read"
+                }
+            ]
+        },
+        "/lnrpc.Lightning/ListPayments": {
+            "permissions": [
+                {
+                    "entity": "offchain",
+                    "action": "read"
+                }
+            ]
+        },
+        "/lnrpc.Lightning/ListPeers": {
+            "permissions": [
+                {
+                    "entity": "peers",
+                    "action": "read"
+                }
+            ]
+        },
+        "/lnrpc.Lightning/ListPermissions": {
+            "permissions": [
+                {
+                    "entity": "info",
+                    "action": "read"
+                }
+            ]
+        },
+        "/lnrpc.Lightning/ListUnspent": {
+            "permissions": [
+                {
+                    "entity": "onchain",
+                    "action": "read"
+                }
+            ]
+        },
+        "/lnrpc.Lightning/LookupInvoice": {
+            "permissions": [
+                {
+                    "entity": "invoices",
+                    "action": "read"
+                }
+            ]
+        },
+        "/lnrpc.Lightning/NewAddress": {
+            "permissions": [
+                {
+                    "entity": "address",
+                    "action": "write"
+                }
+            ]
+        },
+        "/lnrpc.Lightning/OpenChannel": {
+            "permissions": [
+                {
+                    "entity": "onchain",
+                    "action": "write"
+                },
+                {
+                    "entity": "offchain",
+                    "action": "write"
+                }
+            ]
+        },
+        "/lnrpc.Lightning/OpenChannelSync": {
+            "permissions": [
+                {
+                    "entity": "onchain",
+                    "action": "write"
+                },
+                {
+                    "entity": "offchain",
+                    "action": "write"
+                }
+            ]
+        },
+        "/lnrpc.Lightning/PendingChannels": {
+            "permissions": [
+                {
+                    "entity": "offchain",
+                    "action": "read"
+                }
+            ]
+        },
+        "/lnrpc.Lightning/QueryRoutes": {
+            "permissions": [
+                {
+                    "entity": "info",
+                    "action": "read"
+                }
+            ]
+        },
+        "/lnrpc.Lightning/RestoreChannelBackups": {
+            "permissions": [
+                {
+                    "entity": "offchain",
+                    "action": "write"
+                }
+            ]
+        },
+        "/lnrpc.Lightning/SendCoins": {
+            "permissions": [
+                {
+                    "entity": "onchain",
+                    "action": "write"
+                }
+            ]
+        },
+        "/lnrpc.Lightning/SendMany": {
+            "permissions": [
+                {
+                    "entity": "onchain",
+                    "action": "write"
+                }
+            ]
+        },
+        "/lnrpc.Lightning/SendPayment": {
+            "permissions": [
+                {
+                    "entity": "offchain",
+                    "action": "write"
+                }
+            ]
+        },
+        "/lnrpc.Lightning/SendPaymentSync": {
+            "permissions": [
+                {
+                    "entity": "offchain",
+                    "action": "write"
+                }
+            ]
+        },
+        "/lnrpc.Lightning/SendToRoute": {
+            "permissions": [
+                {
+                    "entity": "offchain",
+                    "action": "write"
+                }
+            ]
+        },
+        "/lnrpc.Lightning/SendToRouteSync": {
+            "permissions": [
+                {
+                    "entity": "offchain",
+                    "action": "write"
+                }
+            ]
+        },
+        "/lnrpc.Lightning/SignMessage": {
+            "permissions": [
+                {
+                    "entity": "message",
+                    "action": "write"
+                }
+            ]
+        },
+        "/lnrpc.Lightning/StopDaemon": {
+            "permissions": [
+                {
+                    "entity": "info",
+                    "action": "write"
+                }
+            ]
+        },
+        "/lnrpc.Lightning/SubscribeChannelBackups": {
+            "permissions": [
+                {
+                    "entity": "offchain",
+                    "action": "read"
+                }
+            ]
+        },
+        "/lnrpc.Lightning/SubscribeChannelEvents": {
+            "permissions": [
+                {
+                    "entity": "offchain",
+                    "action": "read"
+                }
+            ]
+        },
+        "/lnrpc.Lightning/SubscribeChannelGraph": {
+            "permissions": [
+                {
+                    "entity": "info",
+                    "action": "read"
+                }
+            ]
+        },
+        "/lnrpc.Lightning/SubscribeInvoices": {
+            "permissions": [
+                {
+                    "entity": "invoices",
+                    "action": "read"
+                }
+            ]
+        },
+        "/lnrpc.Lightning/SubscribePeerEvents": {
+            "permissions": [
+                {
+                    "entity": "peers",
+                    "action": "read"
+                }
+            ]
+        },
+        "/lnrpc.Lightning/SubscribeTransactions": {
+            "permissions": [
+                {
+                    "entity": "onchain",
+                    "action": "read"
+                }
+            ]
+        },
+        "/lnrpc.Lightning/UpdateChannelPolicy": {
+            "permissions": [
+                {
+                    "entity": "offchain",
+                    "action": "write"
+                }
+            ]
+        },
+        "/lnrpc.Lightning/VerifyChanBackup": {
+            "permissions": [
+                {
+                    "entity": "offchain",
+                    "action": "read"
+                }
+            ]
+        },
+        "/lnrpc.Lightning/VerifyMessage": {
+            "permissions": [
+                {
+                    "entity": "message",
+                    "action": "read"
+                }
+            ]
+        },
+        "/lnrpc.Lightning/WalletBalance": {
+            "permissions": [
+                {
+                    "entity": "onchain",
+                    "action": "read"
+                }
+            ]
+        },
+        "/routerrpc.Router/BuildRoute": {
+            "permissions": [
+                {
+                    "entity": "offchain",
+                    "action": "read"
+                }
+            ]
+        },
+        "/routerrpc.Router/EstimateRouteFee": {
+            "permissions": [
+                {
+                    "entity": "offchain",
+                    "action": "read"
+                }
+            ]
+        },
+        "/routerrpc.Router/HtlcInterceptor": {
+            "permissions": [
+                {
+                    "entity": "offchain",
+                    "action": "write"
+                }
+            ]
+        },
+        "/routerrpc.Router/QueryMissionControl": {
+            "permissions": [
+                {
+                    "entity": "offchain",
+                    "action": "read"
+                }
+            ]
+        },
+        "/routerrpc.Router/QueryProbability": {
+            "permissions": [
+                {
+                    "entity": "offchain",
+                    "action": "read"
+                }
+            ]
+        },
+        "/routerrpc.Router/ResetMissionControl": {
+            "permissions": [
+                {
+                    "entity": "offchain",
+                    "action": "write"
+                }
+            ]
+        },
+        "/routerrpc.Router/SendPayment": {
+            "permissions": [
+                {
+                    "entity": "offchain",
+                    "action": "write"
+                }
+            ]
+        },
+        "/routerrpc.Router/SendPaymentV2": {
+            "permissions": [
+                {
+                    "entity": "offchain",
+                    "action": "write"
+                }
+            ]
+        },
+        "/routerrpc.Router/SendToRoute": {
+            "permissions": [
+                {
+                    "entity": "offchain",
+                    "action": "write"
+                }
+            ]
+        },
+        "/routerrpc.Router/SendToRouteV2": {
+            "permissions": [
+                {
+                    "entity": "offchain",
+                    "action": "write"
+                }
+            ]
+        },
+        "/routerrpc.Router/SubscribeHtlcEvents": {
+            "permissions": [
+                {
+                    "entity": "offchain",
+                    "action": "read"
+                }
+            ]
+        },
+        "/routerrpc.Router/TrackPayment": {
+            "permissions": [
+                {
+                    "entity": "offchain",
+                    "action": "read"
+                }
+            ]
+        },
+        "/routerrpc.Router/TrackPaymentV2": {
+            "permissions": [
+                {
+                    "entity": "offchain",
+                    "action": "read"
+                }
+            ]
+        },
+        "/signrpc.Signer/ComputeInputScript": {
+            "permissions": [
+                {
+                    "entity": "signer",
+                    "action": "generate"
+                }
+            ]
+        },
+        "/signrpc.Signer/DeriveSharedKey": {
+            "permissions": [
+                {
+                    "entity": "signer",
+                    "action": "generate"
+                }
+            ]
+        },
+        "/signrpc.Signer/SignMessage": {
+            "permissions": [
+                {
+                    "entity": "signer",
+                    "action": "generate"
+                }
+            ]
+        },
+        "/signrpc.Signer/SignOutputRaw": {
+            "permissions": [
+                {
+                    "entity": "signer",
+                    "action": "generate"
+                }
+            ]
+        },
+        "/signrpc.Signer/VerifyMessage": {
+            "permissions": [
+                {
+                    "entity": "signer",
+                    "action": "read"
+                }
+            ]
+        },
+        "/verrpc.Versioner/GetVersion": {
+            "permissions": [
+                {
+                    "entity": "info",
+                    "action": "read"
+                }
+            ]
+        },
+        "/walletrpc.WalletKit/BumpFee": {
+            "permissions": [
+                {
+                    "entity": "onchain",
+                    "action": "write"
+                }
+            ]
+        },
+        "/walletrpc.WalletKit/DeriveKey": {
+            "permissions": [
+                {
+                    "entity": "address",
+                    "action": "read"
+                }
+            ]
+        },
+        "/walletrpc.WalletKit/DeriveNextKey": {
+            "permissions": [
+                {
+                    "entity": "address",
+                    "action": "read"
+                }
+            ]
+        },
+        "/walletrpc.WalletKit/EstimateFee": {
+            "permissions": [
+                {
+                    "entity": "onchain",
+                    "action": "read"
+                }
+            ]
+        },
+        "/walletrpc.WalletKit/FinalizePsbt": {
+            "permissions": [
+                {
+                    "entity": "onchain",
+                    "action": "write"
+                }
+            ]
+        },
+        "/walletrpc.WalletKit/FundPsbt": {
+            "permissions": [
+                {
+                    "entity": "onchain",
+                    "action": "write"
+                }
+            ]
+        },
+        "/walletrpc.WalletKit/LabelTransaction": {
+            "permissions": [
+                {
+                    "entity": "onchain",
+                    "action": "write"
+                }
+            ]
+        },
+        "/walletrpc.WalletKit/LeaseOutput": {
+            "permissions": [
+                {
+                    "entity": "onchain",
+                    "action": "write"
+                }
+            ]
+        },
+        "/walletrpc.WalletKit/ListSweeps": {
+            "permissions": [
+                {
+                    "entity": "onchain",
+                    "action": "read"
+                }
+            ]
+        },
+        "/walletrpc.WalletKit/ListUnspent": {
+            "permissions": [
+                {
+                    "entity": "onchain",
+                    "action": "read"
+                }
+            ]
+        },
+        "/walletrpc.WalletKit/NextAddr": {
+            "permissions": [
+                {
+                    "entity": "address",
+                    "action": "read"
+                }
+            ]
+        },
+        "/walletrpc.WalletKit/PendingSweeps": {
+            "permissions": [
+                {
+                    "entity": "onchain",
+                    "action": "read"
+                }
+            ]
+        },
+        "/walletrpc.WalletKit/PublishTransaction": {
+            "permissions": [
+                {
+                    "entity": "onchain",
+                    "action": "write"
+                }
+            ]
+        },
+        "/walletrpc.WalletKit/ReleaseOutput": {
+            "permissions": [
+                {
+                    "entity": "onchain",
+                    "action": "write"
+                }
+            ]
+        },
+        "/walletrpc.WalletKit/SendOutputs": {
+            "permissions": [
+                {
+                    "entity": "onchain",
+                    "action": "write"
+                }
+            ]
+        },
+        "/watchtowerrpc.Watchtower/GetInfo": {
+            "permissions": [
+                {
+                    "entity": "info",
+                    "action": "read"
+                }
+            ]
+        },
+        "/wtclientrpc.WatchtowerClient/AddTower": {
+            "permissions": [
+                {
+                    "entity": "offchain",
+                    "action": "write"
+                }
+            ]
+        },
+        "/wtclientrpc.WatchtowerClient/GetTowerInfo": {
+            "permissions": [
+                {
+                    "entity": "offchain",
+                    "action": "read"
+                }
+            ]
+        },
+        "/wtclientrpc.WatchtowerClient/ListTowers": {
+            "permissions": [
+                {
+                    "entity": "offchain",
+                    "action": "read"
+                }
+            ]
+        },
+        "/wtclientrpc.WatchtowerClient/Policy": {
+            "permissions": [
+                {
+                    "entity": "offchain",
+                    "action": "read"
+                }
+            ]
+        },
+        "/wtclientrpc.WatchtowerClient/RemoveTower": {
+            "permissions": [
+                {
+                    "entity": "offchain",
+                    "action": "write"
+                }
+            ]
+        },
+        "/wtclientrpc.WatchtowerClient/Stats": {
+            "permissions": [
+                {
+                    "entity": "offchain",
+                    "action": "read"
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
Addresses the problem described in https://github.com/lightninglabs/loop/issues/299.

This PR adds two functionalities:
1. Allow one custom macaroon to be specified (by providing `CustomMacaroonPath` instead of `MacaroonDir` in `NewLndServices`) instead of needing to have all `lnd` macaroons in the same directory. This allows users to use the `admin.macaroon` or a custom baked one.
2. To make it easy to get a "macaroon recipe" for all required subservers, a new helper function `MacaroonRecipe` is added. This requires the `lnrpc.Lightning.ListPermissions` RPC which was only added in `lnd v0.11.1`.

**NOTE:** This PR is against the `lnd-11-1` branch as it requires a compile-time dependency to that version. This code can also be used with older `lnd` versions but then the `MacaroonRecipe` function will throw an error.