### PR TITLE
lndclient: add all functions required for lndmon

### DIFF
--- a/lightning_client.go
+++ b/lightning_client.go
@@ -135,6 +135,9 @@ type LightningClient interface {
 	SendCoins(ctx context.Context, addr btcutil.Address,
 		amount btcutil.Amount, sendAll bool, confTarget int32,
 		satsPerByte int64, label string) (string, error)
+
+	// ChannelBalance returns a summary of our channel balances.
+	ChannelBalance(ctx context.Context) (*ChannelBalance, error)
 }
 
 // Info contains info about the connected lnd node.
@@ -444,6 +447,15 @@ type Peer struct {
 
 	// PingTime is the estimated round trip time to this peer.
 	PingTime time.Duration
+}
+
+// ChannelBalance contains information about our channel balances.
+type ChannelBalance struct {
+	// Balance is the sum of all open channels balances denominated.
+	Balance btcutil.Amount
+
+	// PendingBalance is the sum of all pending channel balances.
+	PendingBalance btcutil.Amount
 }
 
 var (
@@ -2340,4 +2352,26 @@ func (s *lightningClient) SendCoins(ctx context.Context, addr btcutil.Address,
 	}
 
 	return resp.Txid, nil
+}
+
+// ChannelBalance returns a summary of our channel balances.
+func (s *lightningClient) ChannelBalance(ctx context.Context) (*ChannelBalance,
+	error) {
+
+	rpcCtx, cancel := context.WithTimeout(ctx, rpcTimeout)
+	defer cancel()
+
+	rpcCtx = s.adminMac.WithMacaroonAuth(rpcCtx)
+
+	resp, err := s.client.ChannelBalance(
+		rpcCtx, &lnrpc.ChannelBalanceRequest{},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ChannelBalance{
+		Balance:        btcutil.Amount(resp.Balance),
+		PendingBalance: btcutil.Amount(resp.PendingOpenBalance),
+	}, nil
 }

--- a/lightning_client.go
+++ b/lightning_client.go
@@ -139,11 +139,23 @@ type LightningClient interface {
 
 // Info contains info about the connected lnd node.
 type Info struct {
-	BlockHeight    uint32
+	// Version is the version that lnd is running.
+	Version string
+
+	// BlockHeight is the best block height that lnd has knowledge of.
+	BlockHeight uint32
+
+	// IdentityPubkey is our node's pubkey.
 	IdentityPubkey [33]byte
-	Alias          string
-	Network        string
-	Uris           []string
+
+	// Alias is our node's alias.
+	Alias string
+
+	// Network is the network we are currently operating on.
+	Network string
+
+	// Uris is the set of our node's advertised uris.
+	Uris []string
 
 	// SyncedToChain is true if the wallet's view is synced to the main
 	// chain.
@@ -152,6 +164,18 @@ type Info struct {
 	// SyncedToGraph is true if we consider ourselves to be synced with the
 	// public channel graph.
 	SyncedToGraph bool
+
+	// BestHeaderTimeStamp is the best block timestamp known to the wallet.
+	BestHeaderTimeStamp time.Time
+
+	// ActiveChannels is the number of active channels we have.
+	ActiveChannels uint32
+
+	// InactiveChannels is the number of inactive channels we have.
+	InactiveChannels uint32
+
+	// PendingChannels is the number of pending channels we have.
+	PendingChannels uint32
 }
 
 // ChannelInfo stores unpacked per-channel info.
@@ -517,13 +541,18 @@ func (s *lightningClient) GetInfo(ctx context.Context) (*Info, error) {
 	copy(pubKeyArray[:], pubKey)
 
 	return &Info{
-		BlockHeight:    resp.BlockHeight,
-		IdentityPubkey: pubKeyArray,
-		Alias:          resp.Alias,
-		Network:        resp.Chains[0].Network,
-		Uris:           resp.Uris,
-		SyncedToChain:  resp.SyncedToChain,
-		SyncedToGraph:  resp.SyncedToGraph,
+		Version:             resp.Version,
+		BlockHeight:         resp.BlockHeight,
+		IdentityPubkey:      pubKeyArray,
+		Alias:               resp.Alias,
+		Network:             resp.Chains[0].Network,
+		Uris:                resp.Uris,
+		SyncedToChain:       resp.SyncedToChain,
+		SyncedToGraph:       resp.SyncedToGraph,
+		BestHeaderTimeStamp: time.Unix(resp.BestHeaderTimestamp, 0),
+		ActiveChannels:      resp.NumActiveChannels,
+		InactiveChannels:    resp.NumInactiveChannels,
+		PendingChannels:     resp.NumPendingChannels,
 	}, nil
 }
 

--- a/lightning_client.go
+++ b/lightning_client.go
@@ -570,6 +570,12 @@ type Peer struct {
 
 	// PingTime is the estimated round trip time to this peer.
 	PingTime time.Duration
+
+	// Sent is the total amount we have sent to this peer.
+	Sent btcutil.Amount
+
+	// Received is the total amount we have received from this peer.
+	Received btcutil.Amount
 }
 
 // ChannelBalance contains information about our channel balances.
@@ -2459,6 +2465,8 @@ func (s *lightningClient) ListPeers(ctx context.Context) ([]Peer,
 			BytesReceived: peer.BytesRecv,
 			Inbound:       peer.Inbound,
 			PingTime:      pingTime,
+			Sent:          btcutil.Amount(peer.SatSent),
+			Received:      btcutil.Amount(peer.SatRecv),
 		}
 	}
 


### PR DESCRIPTION
As part of github.com/lightninglabs/lndmon/issues/57 , I am going to switchover lndmon to use the full set of lnd servcies (rather than just the basic client), since we will need to add `routerrpc` anyway for htlc stream, we might as well go all the way now. 

This PR adds all the functions/fields that lndmon will require to switchover to the full client. I have a WIP for lndmon [here](https://github.com/carlaKC/lndmon/tree/57-lndlcientswitchover) which is working with this set of changes. 