### PR TITLE
Implement macaroon-permission-based client loading

### DIFF
--- a/chainnotifier_client.go
+++ b/chainnotifier_client.go
@@ -3,6 +3,7 @@ package lndclient
 import (
 	"context"
 	"fmt"
+	"gopkg.in/macaroon-bakery.v2/bakery"
 	"sync"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
@@ -24,6 +25,13 @@ type ChainNotifierClient interface {
 	RegisterSpendNtfn(ctx context.Context,
 		outpoint *wire.OutPoint, pkScript []byte, heightHint int32) (
 		chan *chainntnfs.SpendDetail, chan error, error)
+}
+
+var chainNotifierRequiredPermissions = []bakery.Op{
+	{
+		Entity: "onchain",
+		Action: "read",
+	},
 }
 
 type chainNotifierClient struct {

--- a/invoices_client.go
+++ b/invoices_client.go
@@ -3,6 +3,7 @@ package lndclient
 import (
 	"context"
 	"errors"
+	"gopkg.in/macaroon-bakery.v2/bakery"
 	"sync"
 
 	"github.com/btcsuite/btcutil"
@@ -30,6 +31,17 @@ type InvoicesClient interface {
 type InvoiceUpdate struct {
 	State   channeldb.ContractState
 	AmtPaid btcutil.Amount
+}
+
+var invoicesRequiredPermissions = []bakery.Op{
+	{
+		Entity: "invoices",
+		Action: "write",
+	},
+	{
+		Entity: "invoices",
+		Action: "read",
+	},
 }
 
 type invoicesClient struct {

--- a/lightning_client.go
+++ b/lightning_client.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"gopkg.in/macaroon-bakery.v2/bakery"
 	"io"
 	"sync"
 	"time"
@@ -825,6 +826,84 @@ type lightningClient struct {
 	wg       sync.WaitGroup
 	params   *chaincfg.Params
 	adminMac serializedMacaroon
+}
+
+var lightningRequiredPermissions = []bakery.Op{
+	{
+		Entity: "address",
+		Action: "read",
+	},
+	{
+		Entity: "address",
+		Action: "write",
+	},
+	{
+		Entity: "message",
+		Action: "read",
+	},
+	{
+		Entity: "message",
+		Action: "write",
+	},
+	{
+		Entity: "peers",
+		Action: "read",
+	},
+	{
+		Entity: "peers",
+		Action: "write",
+	},
+	{
+		Entity: "onchain",
+		Action: "read",
+	},
+	{
+		Entity: "onchain",
+		Action: "write",
+	},
+	{
+		Entity: "invoices",
+		Action: "read",
+	},
+	{
+		Entity: "invoices",
+		Action: "write",
+	},
+	{
+		Entity: "info",
+		Action: "read",
+	},
+	{
+		Entity: "info",
+		Action: "write",
+	},
+	{
+		Entity: "offchain",
+		Action: "read",
+	},
+	{
+		Entity: "offchain",
+		Action: "write",
+	},
+	{
+		Entity: "macaroon",
+		Action: "read",
+	},
+	{
+		Entity: "macaroon",
+		Action: "write",
+	},
+	{
+		Entity: "macaroon",
+		Action: "generate",
+	},
+}
+
+var readOnlyRequiredPermssions = []bakery.Op{
+	{
+		Entity: "info",
+		Action: "read",
+	},
 }
 
 func newLightningClient(conn *grpc.ClientConn,

--- a/macaroon_permissions.go
+++ b/macaroon_permissions.go
@@ -1,0 +1,93 @@
+package lndclient
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"gopkg.in/macaroon-bakery.v2/bakery"
+	"gopkg.in/macaroon.v2"
+)
+
+func loadAvailablePermissions(macPouch *macaroonPouch) *availablePermissions {
+	return &availablePermissions{
+		lightning:     checkMacaroonPermissions(macPouch.adminMac, lightningRequiredPermissions),
+		walletKit:     checkMacaroonPermissions(macPouch.walletKitMac, walletKitRequiredPermissions),
+		invoices:      checkMacaroonPermissions(macPouch.invoiceMac, invoicesRequiredPermissions),
+		signer:        checkMacaroonPermissions(macPouch.signerMac, signerRequiredPermissions),
+		chainNotifier: checkMacaroonPermissions(macPouch.chainMac, chainNotifierRequiredPermissions),
+		router:        checkMacaroonPermissions(macPouch.routerMac, routerRequiredPermissions),
+		readOnly:      checkMacaroonPermissions(macPouch.readonlyMac, readOnlyRequiredPermssions),
+	}
+}
+
+// checkMacaroonPermissions takes a serializedMacaroon
+// and checks that it has all of the required permissions for
+// a given client.
+// Returns false and an error if an error occurs while loading
+// the macaroon data or creating a bakery.Oven.
+func checkMacaroonPermissions(mac serializedMacaroon,
+	requiredPermissions []bakery.Op) bool {
+
+	m, err := unmarshalMacaroon(mac)
+	if err != nil {
+		log.Error(err)
+		return false
+	}
+
+	macOven := bakery.NewOven(bakery.OvenParams{})
+
+	ops, _, err := macOven.VerifyMacaroon(context.Background(), []*macaroon.Macaroon{m})
+	if err != nil {
+		log.Error(err)
+		return false
+	}
+
+	macOpsMap := convertMacOpsToMap(ops)
+	requiredPermsMap := convertMacOpsToMap(requiredPermissions)
+	permissionsMap := make(map[string]bool)
+
+	// appends all matched permissions in macOpsMap
+	// to permissionsMap
+	for permName := range requiredPermsMap {
+		if _, ok := macOpsMap[permName]; ok {
+			permissionsMap[permName] = true
+		}
+	}
+
+	hasAllPermissions := len(permissionsMap) == len(requiredPermissions)
+
+	return hasAllPermissions
+}
+
+// convertMacOpsToMap converts a slice of bakery.Op into a map[string]bool
+// by concatenating the entity name and action into a single string;
+// for example, { Entity: "address", Action: "read" } becomes "address.read".
+func convertMacOpsToMap(ops []bakery.Op) map[string]bool {
+	opsMap := make(map[string]bool)
+
+	for _, op := range ops {
+		macOp := fmt.Sprintf("%[1]s.%[2]s", op.Entity, op.Action)
+
+		_, ok := opsMap[macOp]
+		if !ok {
+			opsMap[macOp] = true
+		}
+	}
+
+	return opsMap
+}
+
+func unmarshalMacaroon(mac serializedMacaroon) (*macaroon.Macaroon, error) {
+	var m = &macaroon.Macaroon{}
+
+	deserializedMac, err := hex.DecodeString(string(mac))
+	if err != nil {
+		return nil, fmt.Errorf("could not deserialize macaroon: %[1]v", err)
+	}
+
+	if err := m.UnmarshalBinary(deserializedMac); err != nil {
+		return nil, fmt.Errorf("could not unmarshal macaroon data: %[1]v", err)
+	}
+
+	return m, nil
+}

--- a/router_client.go
+++ b/router_client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
+	"gopkg.in/macaroon-bakery.v2/bakery"
 	"io"
 	"time"
 
@@ -129,6 +130,17 @@ type SendPaymentRequest struct {
 
 	// If set, circular payments to self are permitted.
 	AllowSelfPayment bool
+}
+
+var routerRequiredPermissions = []bakery.Op{
+	{
+		Entity: "offchain",
+		Action: "read",
+	},
+	{
+		Entity: "offchain",
+		Action: "write",
+	},
 }
 
 // routerClient is a wrapper around the generated routerrpc proxy.

--- a/signer_client.go
+++ b/signer_client.go
@@ -2,6 +2,7 @@ package lndclient
 
 import (
 	"context"
+	"gopkg.in/macaroon-bakery.v2/bakery"
 
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcd/txscript"
@@ -105,6 +106,17 @@ type SignDescriptor struct {
 	// InputIndex is the target input within the transaction that should be
 	// signed.
 	InputIndex int
+}
+
+var signerRequiredPermissions = []bakery.Op{
+	{
+		Entity: "signer",
+		Action: "generate",
+	},
+	{
+		Entity: "signer",
+		Action: "read",
+	},
 }
 
 type signerClient struct {

--- a/walletkit_client.go
+++ b/walletkit_client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"gopkg.in/macaroon-bakery.v2/bakery"
 	"time"
 
 	"github.com/btcsuite/btcd/btcec"
@@ -75,6 +76,25 @@ type WalletKitClient interface {
 type walletKitClient struct {
 	client       walletrpc.WalletKitClient
 	walletKitMac serializedMacaroon
+}
+
+var walletKitRequiredPermissions = []bakery.Op{
+	{
+		Entity: "address",
+		Action: "write",
+	},
+	{
+		Entity: "address",
+		Action: "read",
+	},
+	{
+		Entity: "onchain",
+		Action: "write",
+	},
+	{
+		Entity: "onchain",
+		Action: "read",
+	},
 }
 
 // A compile-time constraint to ensure walletKitclient satisfies the


### PR DESCRIPTION
This commit changes core behavior of LndServices; instead of relying on
macaroons for all rpc clients to be available, it instead checks the
permissions of loaded macaroon files, and determines which clients can
be loaded from there.

If a read-only macaroon is not available for client compatibility
checking, or admin permissions are not available for a Lightning client,
the initialization function will return an error.

#### Pull Request Checklist

- [x] PR is opened against correct version branch.
- [x] Version compatibility matrix in the README and minimal required version
      in `lnd_services.go` are updated.
