### PR TITLE
Expose Htlc CustomRecords

### DIFF
--- a/lightning_client.go
+++ b/lightning_client.go
@@ -1177,6 +1177,9 @@ type InvoiceHtlc struct {
 	// ResolveTime is the time that the htlc was resolved (settled or failed
 	// back).
 	ResolveTime time.Time
+
+	// CustomRecords is list of the custom tlv records.
+	CustomRecords map[uint64][]byte
 }
 
 // LookupInvoice looks up an invoice in lnd, it will error if the invoice is
@@ -1228,8 +1231,9 @@ func unmarshalInvoice(resp *lnrpc.Invoice) (*Invoice, error) {
 
 	for i, htlc := range resp.Htlcs {
 		invoiceHtlc := InvoiceHtlc{
-			ChannelID: lnwire.NewShortChanIDFromInt(htlc.ChanId),
-			Amount:    lnwire.MilliSatoshi(htlc.AmtMsat),
+			ChannelID:     lnwire.NewShortChanIDFromInt(htlc.ChanId),
+			Amount:        lnwire.MilliSatoshi(htlc.AmtMsat),
+			CustomRecords: htlc.CustomRecords,
 		}
 
 		if htlc.AcceptTime != 0 {


### PR DESCRIPTION
In order to be able to use the custom tlv records of the invoices, I've exposed them in the InvoiceHtlc struct.