### PR TITLE
mod: bump to final version of lnd v0.12.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,7 @@ require (
 	github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f
 	github.com/btcsuite/btcutil v1.0.2
 	github.com/btcsuite/btcwallet/wtxmgr v1.2.0
-	//TODO(carla): bump to 0.12 once cut.
-	github.com/lightningnetwork/lnd v0.12.0-beta.rc6
+	github.com/lightningnetwork/lnd v0.12.0-beta
 	github.com/stretchr/testify v1.5.1
 	google.golang.org/grpc v1.24.0
 	gopkg.in/macaroon.v2 v2.1.0

--- a/go.sum
+++ b/go.sum
@@ -172,8 +172,8 @@ github.com/lightninglabs/neutrino v0.11.1-0.20201210023533-e1978372d15e/go.mod h
 github.com/lightninglabs/protobuf-hex-display v1.3.3-0.20191212020323-b444784ce75d/go.mod h1:KDb67YMzoh4eudnzClmvs2FbiLG9vxISmLApUkCa4uI=
 github.com/lightningnetwork/lightning-onion v1.0.2-0.20200501022730-3c8c8d0b89ea h1:oCj48NQ8u7Vz+MmzHqt0db6mxcFZo3Ho7M5gCJauY/k=
 github.com/lightningnetwork/lightning-onion v1.0.2-0.20200501022730-3c8c8d0b89ea/go.mod h1:rigfi6Af/KqsF7Za0hOgcyq2PNH4AN70AaMRxcJkff4=
-github.com/lightningnetwork/lnd v0.12.0-beta.rc6 h1:LtIt2vtNZ/lfhapeSGXST+MLZIeIDrhnOFrJ2BwLIRw=
-github.com/lightningnetwork/lnd v0.12.0-beta.rc6/go.mod h1:2GyP1IG1kXV5Af/LOCxnXfux1OP3fAGr8zptS5PB2YI=
+github.com/lightningnetwork/lnd v0.12.0-beta h1:m4Whrt0dvlnVD6OQT8kDd2utulnoZEcrq8BJlEPSiiY=
+github.com/lightningnetwork/lnd v0.12.0-beta/go.mod h1:2GyP1IG1kXV5Af/LOCxnXfux1OP3fAGr8zptS5PB2YI=
 github.com/lightningnetwork/lnd/cert v1.0.3/go.mod h1:3MWXVLLPI0Mg0XETm9fT4N9Vyy/8qQLmaM5589bEggM=
 github.com/lightningnetwork/lnd/clock v1.0.1 h1:QQod8+m3KgqHdvVMV+2DRNNZS1GRFir8mHZYA+Z2hFo=
 github.com/lightningnetwork/lnd/clock v1.0.1/go.mod h1:KnQudQ6w0IAMZi1SgvecLZQZ43ra2vpDNj7H/aasemg=

--- a/lnd_services.go
+++ b/lnd_services.go
@@ -36,11 +36,10 @@ var (
 	// subset of the lndclient functionality is needed, the required build
 	// tags can be adjusted accordingly. This default will be used as a fall
 	// back version if none is specified in the configuration.
-	// TODO(carla): bump to 0.12 once cut
 	minimalCompatibleVersion = &verrpc.Version{
 		AppMajor:  0,
-		AppMinor:  11,
-		AppPatch:  1,
+		AppMinor:  12,
+		AppPatch:  0,
 		BuildTags: DefaultBuildTags,
 	}
 


### PR DESCRIPTION
This PR bumps the `lnd-12-0` branch to the final version of `lnd`.

#### Pull Request Checklist

- [X] PR is opened against correct version branch.
- [X] Version compatibility matrix in the README and minimal required version
      in `lnd_services.go` are updated.
