### PR TITLE
multi: add custom rpc timeout to lndclient

### DIFF
--- a/chainnotifier_client.go
+++ b/chainnotifier_client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
@@ -29,14 +30,18 @@ type ChainNotifierClient interface {
 type chainNotifierClient struct {
 	client   chainrpc.ChainNotifierClient
 	chainMac serializedMacaroon
+	timeout  time.Duration
 
 	wg sync.WaitGroup
 }
 
-func newChainNotifierClient(conn *grpc.ClientConn, chainMac serializedMacaroon) *chainNotifierClient {
+func newChainNotifierClient(conn *grpc.ClientConn,
+	chainMac serializedMacaroon, timeout time.Duration) *chainNotifierClient {
+
 	return &chainNotifierClient{
 		client:   chainrpc.NewChainNotifierClient(conn),
 		chainMac: chainMac,
+		timeout:  timeout,
 	}
 }
 

--- a/router_client.go
+++ b/router_client.go
@@ -140,14 +140,16 @@ type SendPaymentRequest struct {
 type routerClient struct {
 	client       routerrpc.RouterClient
 	routerKitMac serializedMacaroon
+	timeout      time.Duration
 }
 
 func newRouterClient(conn *grpc.ClientConn,
-	routerKitMac serializedMacaroon) *routerClient {
+	routerKitMac serializedMacaroon, timeout time.Duration) *routerClient {
 
 	return &routerClient{
 		client:       routerrpc.NewRouterClient(conn),
 		routerKitMac: routerKitMac,
+		timeout:      timeout,
 	}
 }
 

--- a/versioner_client.go
+++ b/versioner_client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/lightningnetwork/lnd/lnrpc/verrpc"
 	"google.golang.org/grpc"
@@ -19,14 +20,16 @@ type VersionerClient interface {
 type versionerClient struct {
 	client      verrpc.VersionerClient
 	readonlyMac serializedMacaroon
+	timeout     time.Duration
 }
 
 func newVersionerClient(conn *grpc.ClientConn,
-	readonlyMac serializedMacaroon) *versionerClient {
+	readonlyMac serializedMacaroon, timeout time.Duration) *versionerClient {
 
 	return &versionerClient{
 		client:      verrpc.NewVersionerClient(conn),
 		readonlyMac: readonlyMac,
+		timeout:     timeout,
 	}
 }
 
@@ -38,7 +41,7 @@ func (v *versionerClient) GetVersion(ctx context.Context) (*verrpc.Version,
 	error) {
 
 	rpcCtx, cancel := context.WithTimeout(
-		v.readonlyMac.WithMacaroonAuth(ctx), rpcTimeout,
+		v.readonlyMac.WithMacaroonAuth(ctx), v.timeout,
 	)
 	defer cancel()
 	return v.client.GetVersion(rpcCtx, &verrpc.VersionRequest{})

--- a/walletkit_client.go
+++ b/walletkit_client.go
@@ -75,6 +75,7 @@ type WalletKitClient interface {
 type walletKitClient struct {
 	client       walletrpc.WalletKitClient
 	walletKitMac serializedMacaroon
+	timeout      time.Duration
 }
 
 // A compile-time constraint to ensure walletKitclient satisfies the
@@ -82,11 +83,12 @@ type walletKitClient struct {
 var _ WalletKitClient = (*walletKitClient)(nil)
 
 func newWalletKitClient(conn *grpc.ClientConn,
-	walletKitMac serializedMacaroon) *walletKitClient {
+	walletKitMac serializedMacaroon, timeout time.Duration) *walletKitClient {
 
 	return &walletKitClient{
 		client:       walletrpc.NewWalletKitClient(conn),
 		walletKitMac: walletKitMac,
+		timeout:      timeout,
 	}
 }
 
@@ -95,7 +97,7 @@ func newWalletKitClient(conn *grpc.ClientConn,
 func (m *walletKitClient) ListUnspent(ctx context.Context, minConfs,
 	maxConfs int32) ([]*lnwallet.Utxo, error) {
 
-	rpcCtx, cancel := context.WithTimeout(ctx, rpcTimeout)
+	rpcCtx, cancel := context.WithTimeout(ctx, m.timeout)
 	defer cancel()
 
 	rpcCtx = m.walletKitMac.WithMacaroonAuth(rpcCtx)
@@ -153,7 +155,7 @@ func (m *walletKitClient) ListUnspent(ctx context.Context, minConfs,
 func (m *walletKitClient) LeaseOutput(ctx context.Context, lockID wtxmgr.LockID,
 	op wire.OutPoint) (time.Time, error) {
 
-	rpcCtx, cancel := context.WithTimeout(ctx, rpcTimeout)
+	rpcCtx, cancel := context.WithTimeout(ctx, m.timeout)
 	defer cancel()
 
 	rpcCtx = m.walletKitMac.WithMacaroonAuth(rpcCtx)
@@ -177,7 +179,7 @@ func (m *walletKitClient) LeaseOutput(ctx context.Context, lockID wtxmgr.LockID,
 func (m *walletKitClient) ReleaseOutput(ctx context.Context,
 	lockID wtxmgr.LockID, op wire.OutPoint) error {
 
-	rpcCtx, cancel := context.WithTimeout(ctx, rpcTimeout)
+	rpcCtx, cancel := context.WithTimeout(ctx, m.timeout)
 	defer cancel()
 
 	rpcCtx = m.walletKitMac.WithMacaroonAuth(rpcCtx)
@@ -194,7 +196,7 @@ func (m *walletKitClient) ReleaseOutput(ctx context.Context,
 func (m *walletKitClient) DeriveNextKey(ctx context.Context, family int32) (
 	*keychain.KeyDescriptor, error) {
 
-	rpcCtx, cancel := context.WithTimeout(ctx, rpcTimeout)
+	rpcCtx, cancel := context.WithTimeout(ctx, m.timeout)
 	defer cancel()
 
 	rpcCtx = m.walletKitMac.WithMacaroonAuth(rpcCtx)
@@ -222,7 +224,7 @@ func (m *walletKitClient) DeriveNextKey(ctx context.Context, family int32) (
 func (m *walletKitClient) DeriveKey(ctx context.Context, in *keychain.KeyLocator) (
 	*keychain.KeyDescriptor, error) {
 
-	rpcCtx, cancel := context.WithTimeout(ctx, rpcTimeout)
+	rpcCtx, cancel := context.WithTimeout(ctx, m.timeout)
 	defer cancel()
 
 	rpcCtx = m.walletKitMac.WithMacaroonAuth(rpcCtx)
@@ -248,7 +250,7 @@ func (m *walletKitClient) DeriveKey(ctx context.Context, in *keychain.KeyLocator
 func (m *walletKitClient) NextAddr(ctx context.Context) (
 	btcutil.Address, error) {
 
-	rpcCtx, cancel := context.WithTimeout(ctx, rpcTimeout)
+	rpcCtx, cancel := context.WithTimeout(ctx, m.timeout)
 	defer cancel()
 
 	rpcCtx = m.walletKitMac.WithMacaroonAuth(rpcCtx)
@@ -273,7 +275,7 @@ func (m *walletKitClient) PublishTransaction(ctx context.Context,
 		return err
 	}
 
-	rpcCtx, cancel := context.WithTimeout(ctx, rpcTimeout)
+	rpcCtx, cancel := context.WithTimeout(ctx, m.timeout)
 	defer cancel()
 
 	rpcCtx = m.walletKitMac.WithMacaroonAuth(rpcCtx)
@@ -297,7 +299,7 @@ func (m *walletKitClient) SendOutputs(ctx context.Context,
 		}
 	}
 
-	rpcCtx, cancel := context.WithTimeout(ctx, rpcTimeout)
+	rpcCtx, cancel := context.WithTimeout(ctx, m.timeout)
 	defer cancel()
 
 	rpcCtx = m.walletKitMac.WithMacaroonAuth(rpcCtx)
@@ -321,7 +323,7 @@ func (m *walletKitClient) SendOutputs(ctx context.Context,
 func (m *walletKitClient) EstimateFee(ctx context.Context, confTarget int32) (
 	chainfee.SatPerKWeight, error) {
 
-	rpcCtx, cancel := context.WithTimeout(ctx, rpcTimeout)
+	rpcCtx, cancel := context.WithTimeout(ctx, m.timeout)
 	defer cancel()
 
 	rpcCtx = m.walletKitMac.WithMacaroonAuth(rpcCtx)
@@ -339,7 +341,7 @@ func (m *walletKitClient) EstimateFee(ctx context.Context, confTarget int32) (
 // Note that this function only looks up transaction ids (Verbose=false), and
 // does not query our wallet for the full set of transactions.
 func (m *walletKitClient) ListSweeps(ctx context.Context) ([]string, error) {
-	rpcCtx, cancel := context.WithTimeout(ctx, rpcTimeout)
+	rpcCtx, cancel := context.WithTimeout(ctx, m.timeout)
 	defer cancel()
 
 	resp, err := m.client.ListSweeps(
@@ -366,7 +368,7 @@ func (m *walletKitClient) ListSweeps(ctx context.Context) ([]string, error) {
 func (m *walletKitClient) BumpFee(ctx context.Context, op wire.OutPoint,
 	feeRate chainfee.SatPerKWeight) error {
 
-	rpcCtx, cancel := context.WithTimeout(ctx, rpcTimeout)
+	rpcCtx, cancel := context.WithTimeout(ctx, m.timeout)
 	defer cancel()
 
 	_, err := m.client.BumpFee(


### PR DESCRIPTION
Add the option to overwrite our existing hard-set 30 second timeout for lndclient rpc calls.

There is an argument for making this a per-call option, but I think that it's reasonable to have the option to be able to override the default value for all calls? Adding this now doesn't exclude the option of coming back to add per-call timeouts if we want them. 

#### Pull Request Checklist

- [x] PR is opened against correct version branch.
- [x] Version compatibility matrix in the README and minimal required version
      in `lnd_services.go` are updated.
