### PR TITLE
lndservices: use rpc timeout if nonzero

### DIFF
--- a/lnd_services.go
+++ b/lnd_services.go
@@ -259,7 +259,7 @@ func NewLndServices(cfg *LndServicesConfig) (*GrpcLndServices, error) {
 	}
 
 	timeout := defaultRPCTimeout
-	if cfg.RPCTimeout == 0 {
+	if cfg.RPCTimeout != 0 {
 		timeout = cfg.RPCTimeout
 	}
 


### PR DESCRIPTION
#### Pull Request Checklist

- [x] PR is opened against correct version branch.
- [x] Version compatibility matrix in the README and minimal required version
      in `lnd_services.go` are updated.
