### PR TITLE
Subserver timeout fix, add Makefile, run unit tests on CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,12 +16,11 @@ env:
   # go needs absolute directories, using the $HOME variable doesn't work here.
   GOCACHE: /home/runner/work/go/pkg/build
   GOPATH: /home/runner/work/go
-  DOWNLOAD_CACHE: /home/runner/work/download_cache
-  GO_VERSION: 1.14.4
+  GO_VERSION: 1.16.x
 
 jobs:
   build:
-    name: build package
+    name: build package, run linter
     runs-on: ubuntu-latest
     steps:
       - name: git checkout
@@ -31,12 +30,12 @@ jobs:
         uses: actions/cache@v1
         with:
           path: /home/runner/work/go
-          key: lnd-${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ github.job }}-${{ hashFiles('**/go.sum') }}
+          key: lndclient-${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ github.job }}-${{ hashFiles('**/go.sum') }}
           restore-keys: |
-            lnd-${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ github.job }}-${{ hashFiles('**/go.sum') }}
-            lnd-${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ github.job }}-
-            lnd-${{ runner.os }}-go-${{ env.GO_VERSION }}-
-            lnd-${{ runner.os }}-go-
+            lndclient-${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ github.job }}-${{ hashFiles('**/go.sum') }}
+            lndclient-${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ github.job }}-
+            lndclient-${{ runner.os }}-go-${{ env.GO_VERSION }}-
+            lndclient-${{ runner.os }}-go-
 
       - name: setup go ${{ env.GO_VERSION }}
         uses: actions/setup-go@v2
@@ -44,4 +43,10 @@ jobs:
           go-version: '~${{ env.GO_VERSION }}'
 
       - name: compile
-        run: go build
+        run: make build
+
+      - name: lint
+        run: make lint
+
+      - name: unit-race
+        run: make unit-race

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,31 @@
+run:
+  # timeout for analysis
+  deadline: 4m
+
+linters-settings:
+  govet:
+    # Don't report about shadowed variables
+    check-shadowing: false
+  gofmt:
+    # simplify code: gofmt with `-s` option, true by default
+    simplify: true
+
+linters:
+  enable-all: true
+  disable:
+    # Init functions are used by loggers throughout the codebase.
+    - gochecknoinits
+
+    # Global variables are used by loggers.
+    - gochecknoglobals
+
+    # Some lines are over 80 characters on purpose and we don't want to make
+    # them even longer by marking them as 'nolint'.
+    - lll
+
+    # We don't care (enough) about misaligned structs to lint that.
+    - maligned
+
+    # We have long functions, especially in tests. Moving or renaming those
+    # would trigger funlen problems that we may not want to solve at that time.
+    - funlen

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,82 @@
+PKG := github.com/lightninglabs/lndclient
+
+LINT_PKG := github.com/golangci/golangci-lint/cmd/golangci-lint
+
+GO_BIN := ${GOPATH}/bin
+LINT_BIN := $(GO_BIN)/golangci-lint
+
+LINT_COMMIT := v1.18.0
+
+DEPGET := cd /tmp && go get -v
+GOBUILD := go build -v
+GOINSTALL := go install -v
+GOTEST := go test -v
+
+GOFILES_NOVENDOR = $(shell find . -type f -name '*.go' -not -path "./vendor/*")
+GOLIST := go list -deps $(PKG)/... | grep '$(PKG)'| grep -v '/vendor/'
+
+COMMIT := $(shell git describe --abbrev=40 --dirty)
+LDFLAGS := -X $(PKG).Commit=$(COMMIT)
+
+RM := rm -f
+CP := cp
+MAKE := make
+XARGS := xargs -L 1
+
+# Linting uses a lot of memory, so keep it under control by limiting the number
+# of workers if requested.
+ifneq ($(workers),)
+LINT_WORKERS = --concurrency=$(workers)
+endif
+
+LINT = $(LINT_BIN) run -v $(LINT_WORKERS)
+
+GREEN := "\\033[0;32m"
+NC := "\\033[0m"
+define print
+	echo $(GREEN)$1$(NC)
+endef
+
+default: build
+
+all: build check install
+
+# ============
+# DEPENDENCIES
+# ============
+$(LINT_BIN):
+	@$(call print, "Fetching linter")
+	$(DEPGET) $(LINT_PKG)@$(LINT_COMMIT)
+
+# ============
+# INSTALLATION
+# ============
+
+build:
+	@$(call print, "Building lndclient.")
+	$(GOBUILD) -ldflags="$(LDFLAGS)" $(PKG)
+
+# =======
+# TESTING
+# =======
+
+check: unit
+
+unit:
+	@$(call print, "Running unit tests.")
+	$(GOTEST)
+
+unit-race:
+	@$(call print, "Running unit race tests.")
+	env CGO_ENABLED=1 GORACE="history_size=7 halt_on_errors=1" $(GOTEST) -race
+
+# =========
+# UTILITIES
+# =========
+fmt:
+	@$(call print, "Formatting source.")
+	gofmt -l -w -s $(GOFILES_NOVENDOR)
+
+lint: $(LINT_BIN)
+	@$(call print, "Linting source.")
+	$(LINT)

--- a/chainnotifier_client.go
+++ b/chainnotifier_client.go
@@ -111,8 +111,8 @@ func (s *chainNotifierClient) RegisterSpendNtfn(ctx context.Context,
 				return
 			}
 
-			switch c := spendEvent.Event.(type) {
-			case *chainrpc.SpendEvent_Spend:
+			c, ok := spendEvent.Event.(*chainrpc.SpendEvent_Spend)
+			if ok {
 				err := processSpendDetail(c.Spend)
 				if err != nil {
 					errChan <- err

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,5 @@
 module github.com/lightninglabs/lndclient
 
-go 1.13
-
 require (
 	github.com/btcsuite/btcd v0.20.1-beta.0.20200730232343-1db1b6f8217f
 	github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f
@@ -12,3 +10,5 @@ require (
 	google.golang.org/grpc v1.24.0
 	gopkg.in/macaroon.v2 v2.1.0
 )
+
+go 1.15

--- a/invoices_client.go
+++ b/invoices_client.go
@@ -46,6 +46,7 @@ func newInvoicesClient(conn *grpc.ClientConn,
 	return &invoicesClient{
 		client:     invoicesrpc.NewInvoicesClient(conn),
 		invoiceMac: invoiceMac,
+		timeout:    timeout,
 	}
 }
 

--- a/lightning_client.go
+++ b/lightning_client.go
@@ -121,7 +121,7 @@ type LightningClient interface {
 
 	// GetChanInfo returns the channel info for the passed channel,
 	// including the routing policy for both end.
-	GetChanInfo(ctx context.Context, chanId uint64) (*ChannelEdge, error)
+	GetChanInfo(ctx context.Context, chanID uint64) (*ChannelEdge, error)
 
 	// ListPeers gets a list the peers we are currently connected to.
 	ListPeers(ctx context.Context) ([]Peer, error)
@@ -2000,8 +2000,8 @@ func (s *lightningClient) ChannelBackups(ctx context.Context) ([]byte, error) {
 
 // getOutPoint is a helper go convert a hash and output index to
 // a wire.OutPoint object.
-func getOutPoint(txId []byte, idx uint32) (*wire.OutPoint, error) {
-	hash, err := chainhash.NewHash(txId)
+func getOutPoint(txID []byte, idx uint32) (*wire.OutPoint, error) {
+	hash, err := chainhash.NewHash(txID)
 	if err != nil {
 		return nil, err
 	}
@@ -2052,10 +2052,10 @@ func getChannelEventUpdate(rpcChannelEventUpdate *lnrpc.ChannelEventUpdate) (
 	case lnrpc.ChannelEventUpdate_ACTIVE_CHANNEL:
 		result.UpdateType = ActiveChannelUpdate
 		channelPoint := rpcChannelEventUpdate.GetActiveChannel()
-		fundingTxId := channelPoint.FundingTxid.(*lnrpc.ChannelPoint_FundingTxidBytes)
+		fundingTxID := channelPoint.FundingTxid.(*lnrpc.ChannelPoint_FundingTxidBytes)
 
 		result.ChannelPoint, err = getOutPoint(
-			fundingTxId.FundingTxidBytes,
+			fundingTxID.FundingTxidBytes,
 			channelPoint.OutputIndex,
 		)
 		if err != nil {
@@ -2065,10 +2065,10 @@ func getChannelEventUpdate(rpcChannelEventUpdate *lnrpc.ChannelEventUpdate) (
 	case lnrpc.ChannelEventUpdate_INACTIVE_CHANNEL:
 		result.UpdateType = InactiveChannelUpdate
 		channelPoint := rpcChannelEventUpdate.GetInactiveChannel()
-		fundingTxId := channelPoint.FundingTxid.(*lnrpc.ChannelPoint_FundingTxidBytes)
+		fundingTxID := channelPoint.FundingTxid.(*lnrpc.ChannelPoint_FundingTxidBytes)
 
 		result.ChannelPoint, err = getOutPoint(
-			fundingTxId.FundingTxidBytes,
+			fundingTxID.FundingTxidBytes,
 			channelPoint.OutputIndex,
 		)
 		if err != nil {
@@ -2488,7 +2488,7 @@ func (s *lightningClient) UpdateChanPolicy(ctx context.Context,
 			FundingTxid: &lnrpc.ChannelPoint_FundingTxidBytes{
 				FundingTxidBytes: chanPoint.Hash[:],
 			},
-			OutputIndex: uint32(chanPoint.Index),
+			OutputIndex: chanPoint.Index,
 		}
 		rpcReq.Scope = &lnrpc.PolicyUpdateRequest_ChanPoint{
 			ChanPoint: rpcChanPoint,
@@ -2532,10 +2532,10 @@ type RoutingPolicy struct {
 
 // ChannelEdge holds the channel edge information and routing policies.
 type ChannelEdge struct {
-	// The unique channel ID for the channel. The first 3 bytes are the
-	// block height, the next 3 the index within the block, and the last
-	// 2 bytes are the output index for the channel.
-	ChannelId uint64
+	// ChannelID is the unique channel ID for the channel. The first 3 bytes
+	// are the block height, the next 3 the index within the block, and the
+	// last 2 bytes are the output index for the channel.
+	ChannelID uint64
 
 	// ChannelPoint is the funding outpoint of the channel.
 	ChannelPoint string
@@ -2575,7 +2575,7 @@ func getRoutingPolicy(policy *lnrpc.RoutingPolicy) *RoutingPolicy {
 
 // GetChanInfo returns the channel info for the passed channel, including the
 // routing policy for both end.
-func (s *lightningClient) GetChanInfo(ctx context.Context, channelId uint64) (
+func (s *lightningClient) GetChanInfo(ctx context.Context, channelID uint64) (
 	*ChannelEdge, error) {
 
 	rpcCtx, cancel := context.WithTimeout(ctx, s.timeout)
@@ -2584,7 +2584,7 @@ func (s *lightningClient) GetChanInfo(ctx context.Context, channelId uint64) (
 	rpcCtx = s.adminMac.WithMacaroonAuth(rpcCtx)
 
 	rpcRes, err := s.client.GetChanInfo(rpcCtx, &lnrpc.ChanInfoRequest{
-		ChanId: channelId,
+		ChanId: channelID,
 	})
 	if err != nil {
 		return nil, err
@@ -2605,7 +2605,7 @@ func newChannelEdge(rpcRes *lnrpc.ChannelEdge) (*ChannelEdge, error) {
 	}
 
 	return &ChannelEdge{
-		ChannelId:    rpcRes.ChannelId,
+		ChannelID:    rpcRes.ChannelId,
 		ChannelPoint: rpcRes.ChanPoint,
 		Capacity:     btcutil.Amount(rpcRes.Capacity),
 		Node1:        vertex1,

--- a/signer_client.go
+++ b/signer_client.go
@@ -120,6 +120,7 @@ func newSignerClient(conn *grpc.ClientConn,
 	return &signerClient{
 		client:    signrpc.NewSignerClient(conn),
 		signerMac: signerMac,
+		timeout:   timeout,
 	}
 }
 

--- a/walletkit_client.go
+++ b/walletkit_client.go
@@ -328,7 +328,7 @@ func (m *walletKitClient) EstimateFee(ctx context.Context, confTarget int32) (
 
 	rpcCtx = m.walletKitMac.WithMacaroonAuth(rpcCtx)
 	resp, err := m.client.EstimateFee(rpcCtx, &walletrpc.EstimateFeeRequest{
-		ConfTarget: int32(confTarget),
+		ConfTarget: confTarget,
 	})
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
Found while running itests for https://github.com/lightninglabs/faraday/pull/119.

We forgot to add the timeout to two of our subservers.
To avoid this in the future, we're adding a linter config and actually run the linter and unit tests during CI.

#### Pull Request Checklist

- [X] PR is opened against correct version branch.
- [ ] Version compatibility matrix in the README and minimal required version
      in `lnd_services.go` are updated.
