### PR TITLE
lndclient: Use field ValueMsat in invoice to avoid rounding

### DIFF
--- a/lightning_client.go
+++ b/lightning_client.go
@@ -1188,7 +1188,7 @@ func (s *lightningClient) AddInvoice(ctx context.Context,
 
 	rpcIn := &lnrpc.Invoice{
 		Memo:       in.Memo,
-		Value:      int64(in.Value.ToSatoshis()),
+		ValueMsat:  int64(in.Value),
 		Expiry:     in.Expiry,
 		CltvExpiry: in.CltvExpiry,
 		Private:    true,


### PR DESCRIPTION
Change AddInvoice method to avoid invoice rounding to sat by using the Invoice field ValueMsat instead.