### PR TITLE
router: add htlcinterceptor

### DIFF
--- a/lnd_services.go
+++ b/lnd_services.go
@@ -324,6 +324,9 @@ func NewLndServices(cfg *LndServicesConfig) (*GrpcLndServices, error) {
 		log.Debugf("Wait for invoices to finish")
 		invoicesClient.WaitForFinished()
 
+		log.Debugf("Wait for router to finish")
+		routerClient.WaitForFinished()
+
 		log.Debugf("Lnd services finished")
 	}
 

--- a/macaroon_recipes.go
+++ b/macaroon_recipes.go
@@ -37,6 +37,7 @@ var (
 		"UpdateChanPolicy":       "UpdateChannelPolicy",
 		"NetworkInfo":            "GetNetworkInfo",
 		"SubscribeGraph":         "SubscribeChannelGraph",
+		"InterceptHtlcs":         "HtlcInterceptor",
 	}
 )
 


### PR DESCRIPTION
Htlc interceptor has been in lnd since 0.11, so we can add this to master. 

#### Pull Request Checklist

- [x] PR is opened against correct version branch.
- [x] Version compatibility matrix in the README and minimal required version
      in `lnd_services.go` are updated.
- [x] Update `macaroon_recipes.go` if your PR adds a new method that is called
  differently than the RPC method it invokes.
