### PR TITLE
basic_client: make latest change non-breaking

### DIFF
--- a/basic_client_test.go
+++ b/basic_client_test.go
@@ -40,8 +40,8 @@ XhkpT5dliEGFLNe6OOgeWTU1JpEXfCud/GImtNMHQi4EDWQfvWuCNGhOoQ==
 
 	// Make sure it works when data is passed in.
 	_, _, err := parseTLSAndMacaroon(
-		"", "", tlsData, macData, "mainnet", false, false,
-		MacFilename(""),
+		"", "", "mainnet", MacFilename(""), TLSData(tlsData),
+		MacaroonData(macData),
 	)
 	require.NoError(t, err)
 
@@ -65,8 +65,7 @@ XhkpT5dliEGFLNe6OOgeWTU1JpEXfCud/GImtNMHQi4EDWQfvWuCNGhOoQ==
 	require.NoError(t, err)
 
 	_, _, err = parseTLSAndMacaroon(
-		certPath, macPath, "", "", "mainnet", false, false,
-		MacFilename(""),
+		certPath, macPath, "mainnet", MacFilename(""),
 	)
 	require.NoError(t, err)
 }


### PR DESCRIPTION
This PR is opened against the `lnd-13-0` branch!
We fix a breaking change introduced in https://github.com/lightninglabs/lndclient/pull/51 by moving to functional options.

#### Pull Request Checklist

- [X] PR is opened against correct version branch.
- [ ] Version compatibility matrix in the README and minimal required version
      in `lnd_services.go` are updated.
- [ ] Update `macaroon_recipes.go` if your PR adds a new method that is called
  differently than the RPC method it invokes.
