### PR TITLE
lndclient: hotfix: fixes issue where NewMacaroonCredentials returns

### DIFF
--- a/basic_client.go
+++ b/basic_client.go
@@ -115,7 +115,10 @@ func NewBasicConn(lndHost, tlsPath, macDir, network string,
 		}
 
 		// Now we append the macaroon credentials to the dial options.
-		cred := macaroons.NewMacaroonCredential(mac)
+		cred, err := macaroons.NewMacaroonCredential(mac)
+		if err != nil {
+			return err
+		}
 		opts = append(opts, grpc.WithPerRPCCredentials(cred))
 		opts = append(opts, grpc.WithDefaultCallOptions(maxMsgRecvSize))
 	}


### PR DESCRIPTION
`NewMacaroonCredentials` now returns multiple values instead of just one, which breaks lndclient. This PR fixes that

#### Pull Request Checklist

- [ ] PR is opened against correct version branch.
- [ ] Version compatibility matrix in the README and minimal required version
      in `lnd_services.go` are updated.
- [ ] Update `macaroon_recipes.go` if your PR adds a new method that is called
  differently than the RPC method it invokes.
