### PR TITLE
lndclient: add closing txid for waiting close channel response

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The current compatibility matrix reads as follows:
 
 | `lndclient` git tag          | `lnd` version in `go.mod` | minimum required `lnd` version | 
 | ---------------------------- | ------------------------- | ------------------------------ |
-| [`v0.14.2-0`](https://github.com/lightninglabs/lndclient/blob/v0.14.2-0) | `lnd @ 4a62b7cf8c69` | `v0.14.0-beta` |
+| [`v0.14.2-1`](https://github.com/lightninglabs/lndclient/blob/v0.14.2-1) | `v0.14.2-beta` | `v0.14.2-beta` |
 | [`v0.13.0-10`](https://github.com/lightninglabs/lndclient/blob/v0.13.0-10) | `lnd @ d9f0f07142ea` | `v0.13.0-beta` |
 | `master` / [`v0.12.0-13`](https://github.com/lightninglabs/lndclient/blob/v0.12.0-13) | `v0.12.0-beta` | `v0.12.0-beta` |
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ require (
 	github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f
 	github.com/btcsuite/btcutil v1.0.3-0.20210527170813-e2ba6805a890
 	github.com/btcsuite/btcwallet/wtxmgr v1.3.1-0.20210822222949-9b5a201c344c
-	github.com/lightningnetwork/lnd v0.14.1-beta.0.20211207205047-4a62b7cf8c69
+	github.com/lightningnetwork/lnd v0.14.2-beta
 	github.com/stretchr/testify v1.7.0
 	google.golang.org/grpc v1.38.0
 	gopkg.in/macaroon.v2 v2.1.0

--- a/go.sum
+++ b/go.sum
@@ -91,6 +91,8 @@ github.com/btcsuite/btcutil/psbt v1.0.3-0.20210527170813-e2ba6805a890 h1:0xUNvvw
 github.com/btcsuite/btcutil/psbt v1.0.3-0.20210527170813-e2ba6805a890/go.mod h1:LVveMu4VaNSkIRTZu2+ut0HDBRuYjqGocxDMNS1KuGQ=
 github.com/btcsuite/btcwallet v0.13.0 h1:gtLWwueRm27KQiHJpycybv3uMdK1eo87JexfTfzvEhk=
 github.com/btcsuite/btcwallet v0.13.0/go.mod h1:iLN1lG1MW0eREm+SikmPO8AZPz5NglBTEK/ErqkjGpo=
+github.com/btcsuite/btcwallet v0.13.1-0.20211201210108-79de92f527dc h1:lAbAEAp4eWvsSwJfcpdHXpKz78X2sVF9aDK4nJveXmY=
+github.com/btcsuite/btcwallet v0.13.1-0.20211201210108-79de92f527dc/go.mod h1:iLN1lG1MW0eREm+SikmPO8AZPz5NglBTEK/ErqkjGpo=
 github.com/btcsuite/btcwallet/wallet/txauthor v1.0.0/go.mod h1:VufDts7bd/zs3GV13f/lXc/0lXrPnvxD/NvmpG/FEKU=
 github.com/btcsuite/btcwallet/wallet/txauthor v1.1.0 h1:8pO0pvPX1rFRfRiol4oV6kX7dY5y4chPwhfVwUfvwtk=
 github.com/btcsuite/btcwallet/wallet/txauthor v1.1.0/go.mod h1:ktYuJyumYtwG+QQ832Q+kqvxWJRAei3Nqs5qhSn4nww=
@@ -491,6 +493,8 @@ github.com/lightningnetwork/lightning-onion v1.0.2-0.20210520211913-522b799e65b1
 github.com/lightningnetwork/lightning-onion v1.0.2-0.20210520211913-522b799e65b1/go.mod h1:rigfi6Af/KqsF7Za0hOgcyq2PNH4AN70AaMRxcJkff4=
 github.com/lightningnetwork/lnd v0.14.1-beta.0.20211207205047-4a62b7cf8c69 h1:wGA5aHEOOZxS0x1+JGGU3qQnkZwsppgcfxT4FriFssE=
 github.com/lightningnetwork/lnd v0.14.1-beta.0.20211207205047-4a62b7cf8c69/go.mod h1:O+RfobNvOWVhczFpFZUpEWs3ChaJqQrRqrocWXiphDY=
+github.com/lightningnetwork/lnd v0.14.2-beta h1:v5Xgf0HjgA+umoinNrihMSoAuy52tYQnxCzX0wFaRwQ=
+github.com/lightningnetwork/lnd v0.14.2-beta/go.mod h1:BKTR+jbfcyFwsOPb3m8HaM09YmZF/SsbWd5UTCgDZlo=
 github.com/lightningnetwork/lnd/cert v1.1.0/go.mod h1:3MWXVLLPI0Mg0XETm9fT4N9Vyy/8qQLmaM5589bEggM=
 github.com/lightningnetwork/lnd/clock v1.0.1/go.mod h1:KnQudQ6w0IAMZi1SgvecLZQZ43ra2vpDNj7H/aasemg=
 github.com/lightningnetwork/lnd/clock v1.1.0 h1:/yfVAwtPmdx45aQBoXQImeY7sOIEr7IXlImRMBOZ7GQ=
@@ -500,6 +504,8 @@ github.com/lightningnetwork/lnd/healthcheck v1.2.0 h1:00bkNn+hGJM9j3Ht+ulf8YNcSx
 github.com/lightningnetwork/lnd/healthcheck v1.2.0/go.mod h1:WSz3lsUjErJQZ3gb+zW32nM3WIHNiZ3A40GVoaQY5wU=
 github.com/lightningnetwork/lnd/kvdb v1.2.3 h1:ye9mt8wvb55c6uENA/tFUn4+2vpGRqkdCpEw6z0B4+E=
 github.com/lightningnetwork/lnd/kvdb v1.2.3/go.mod h1:x+IpsuDynubjokUofavLXroeGfS/WrqUXXTK6vN/gp4=
+github.com/lightningnetwork/lnd/kvdb v1.3.0 h1:0sadTsmfIoorGvd2zf09q/H7sxa/OU48NCpCQUPNN48=
+github.com/lightningnetwork/lnd/kvdb v1.3.0/go.mod h1:x+IpsuDynubjokUofavLXroeGfS/WrqUXXTK6vN/gp4=
 github.com/lightningnetwork/lnd/queue v1.0.1/go.mod h1:vaQwexir73flPW43Mrm7JOgJHmcEFBWWSl9HlyASoms=
 github.com/lightningnetwork/lnd/queue v1.1.0 h1:YpCJjlIvVxN/R7ww2aNiY8ex7U2fucZDLJ67tI3HFx8=
 github.com/lightningnetwork/lnd/queue v1.1.0/go.mod h1:YTkTVZCxz8tAYreH27EO3s8572ODumWrNdYW2E/YKxg=

--- a/lightning_client.go
+++ b/lightning_client.go
@@ -1778,6 +1778,9 @@ type WaitingCloseChannel struct {
 	//   - ChanStatusCoopBroadcasted|ChanStatusLocalCloseInitiator
 	//   - ChanStatusCoopBroadcasted|ChanStatusRemoteCloseInitiator
 	ChanStatusFlags string
+
+	// CloseTxid is the close transaction that's broadcast.
+	CloseTxid chainhash.Hash
 }
 
 // PendingChannels returns a list of lnd's pending channels.
@@ -1845,12 +1848,18 @@ func (s *lightningClient) PendingChannels(ctx context.Context) (*PendingChannels
 			return nil, err
 		}
 
+		hash, err := chainhash.NewHashFromStr(waiting.ClosingTxid)
+		if err != nil {
+			return nil, err
+		}
+
 		closing := WaitingCloseChannel{
 			PendingChannel:  *channel,
 			LocalTxid:       *local,
 			RemoteTxid:      *remote,
 			RemotePending:   *remotePending,
 			ChanStatusFlags: waiting.Channel.ChanStatusFlags,
+			CloseTxid:       *hash,
 		}
 		pending.WaitingClose[i] = closing
 	}

--- a/lnd_services.go
+++ b/lnd_services.go
@@ -42,7 +42,7 @@ var (
 	minimalCompatibleVersion = &verrpc.Version{
 		AppMajor:  0,
 		AppMinor:  14,
-		AppPatch:  0,
+		AppPatch:  2,
 		BuildTags: DefaultBuildTags,
 	}
 


### PR DESCRIPTION
Bump lnd's version to v0.14.2-beta to include the closing txid from waiting close channel response.