### PR TITLE
lndclient: update tag version

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The current compatibility matrix reads as follows:
 
 | `lndclient` git tag          | `lnd` version in `go.mod` | minimum required `lnd` version | 
 | ---------------------------- | ------------------------- | ------------------------------ |
-| [`v0.14.2-1`](https://github.com/lightninglabs/lndclient/blob/v0.14.2-1) | `v0.14.2-beta` | `v0.14.2-beta` |
+| [`v0.14.2-2`](https://github.com/lightninglabs/lndclient/blob/v0.14.2-2) | `v0.14.2-beta` | `v0.14.2-beta` |
 | [`v0.13.0-10`](https://github.com/lightninglabs/lndclient/blob/v0.13.0-10) | `lnd @ d9f0f07142ea` | `v0.13.0-beta` |
 | `master` / [`v0.12.0-13`](https://github.com/lightninglabs/lndclient/blob/v0.12.0-13) | `v0.12.0-beta` | `v0.12.0-beta` |
 


### PR DESCRIPTION
Made the mistake to publish the `v0.14.2-1` without rebasing the changes last week. And apparently republishing the same tag did not update [the go library cache](https://pkg.go.dev/github.com/lightninglabs/lndclient@v0.14.2-1). Lessons learned.

Now we need to update the tag to include the rebase.

We may do a [module retraction](https://golangtutorial.dev/tips/retract-go-module-versions/) once we start to use go version >= 1.16.