### PR TITLE
router: support forced MC import

### DIFF
--- a/router_client.go
+++ b/router_client.go
@@ -62,7 +62,7 @@ type RouterClient interface {
 
 	// ImportMissionControl imports a set of pathfinding results to lnd.
 	ImportMissionControl(ctx context.Context,
-		entries []MissionControlEntry) error
+		entries []MissionControlEntry, force bool) error
 
 	// ResetMissionControl resets the Mission Control state of lnd.
 	ResetMissionControl(ctx context.Context) error
@@ -950,13 +950,14 @@ func (r *routerClient) QueryMissionControl(ctx context.Context) (
 // ImportMissionControl imports a set of pathfinding results to mission control.
 // These results are not persisted across restarts.
 func (r *routerClient) ImportMissionControl(ctx context.Context,
-	entries []MissionControlEntry) error {
+	entries []MissionControlEntry, force bool) error {
 
 	rpcCtx, cancel := context.WithTimeout(ctx, r.timeout)
 	defer cancel()
 
 	req := &routerrpc.XImportMissionControlRequest{
 		Pairs: make([]*routerrpc.PairHistory, len(entries)),
+		Force: force,
 	}
 
 	for i, entry := range entries {


### PR DESCRIPTION
This PR surfaces the `force` flag when importing MC pair history. When `force` is set, the pairs will overwrite the MC state regardless of freshness.

#### Pull Request Checklist

- [x] PR is opened against correct version branch.
~- [ ] Version compatibility matrix in the README and minimal required version
      in `lnd_services.go` are updated.~
~- [ ] Update `macaroon_recipes.go` if your PR adds a new method that is called
  differently than the RPC method it invokes.~
