### PR TITLE
macaroons: update to new macaroons pkg version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/lightningnetwork/lnd v0.15.0-beta.rc6.0.20220707020049-dc35f78ebce6
 	github.com/lightningnetwork/lnd/kvdb v1.3.1
 	github.com/stretchr/testify v1.7.1
-	go.etcd.io/bbolt v1.3.6
 	google.golang.org/grpc v1.38.0
 	gopkg.in/macaroon-bakery.v2 v2.0.1
 	gopkg.in/macaroon.v2 v2.1.0
@@ -109,6 +108,7 @@ require (
 	github.com/ulikunitz/xz v0.5.10 // indirect
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
 	github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 // indirect
+	go.etcd.io/bbolt v1.3.6 // indirect
 	go.etcd.io/etcd/api/v3 v3.5.0 // indirect
 	go.etcd.io/etcd/client/pkg/v3 v3.5.0 // indirect
 	go.etcd.io/etcd/client/v2 v2.305.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1
 	github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f
 	github.com/btcsuite/btcwallet/wtxmgr v1.5.0
-	github.com/lightningnetwork/lnd v0.15.0-beta
+	github.com/lightningnetwork/lnd v0.15.0-beta.rc6.0.20220707020049-dc35f78ebce6
 	github.com/lightningnetwork/lnd/kvdb v1.3.1
 	github.com/stretchr/testify v1.7.1
 	go.etcd.io/bbolt v1.3.6

--- a/go.sum
+++ b/go.sum
@@ -497,8 +497,8 @@ github.com/lightninglabs/neutrino v0.14.2/go.mod h1:OICUeTCn+4Tu27YRJIpWvvqySxx4
 github.com/lightninglabs/protobuf-hex-display v1.4.3-hex-display/go.mod h1:2oKOBU042GKFHrdbgGiKax4xVrFiZu51lhacUZQ9MnE=
 github.com/lightningnetwork/lightning-onion v1.0.2-0.20220211021909-bb84a1ccb0c5 h1:TkKwqFcQTGYoI+VEqyxA8rxpCin8qDaYX0AfVRinT3k=
 github.com/lightningnetwork/lightning-onion v1.0.2-0.20220211021909-bb84a1ccb0c5/go.mod h1:7dDx73ApjEZA0kcknI799m2O5kkpfg4/gr7N092ojNo=
-github.com/lightningnetwork/lnd v0.15.0-beta h1:smzYjJqL4nGuj4qrAWdikrPzPJ8fcPRFHQ86S2tHR1M=
-github.com/lightningnetwork/lnd v0.15.0-beta/go.mod h1:Tm7LZrYeR2JQH1gEOKmd0NTCgjJ1Bnujkx4lcz9b5+A=
+github.com/lightningnetwork/lnd v0.15.0-beta.rc6.0.20220707020049-dc35f78ebce6 h1:wd+aDsGCWNEt0NB9bI2oWi/Vn8z76wTBJxLRAZHZaRI=
+github.com/lightningnetwork/lnd v0.15.0-beta.rc6.0.20220707020049-dc35f78ebce6/go.mod h1:sa+hYajDLPn2I2zG99ylXOCF3yK3AQqFu0M0v97vh08=
 github.com/lightningnetwork/lnd/cert v1.1.1/go.mod h1:1P46svkkd73oSoeI4zjkVKgZNwGq8bkGuPR8z+5vQUs=
 github.com/lightningnetwork/lnd/clock v1.0.1/go.mod h1:KnQudQ6w0IAMZi1SgvecLZQZ43ra2vpDNj7H/aasemg=
 github.com/lightningnetwork/lnd/clock v1.1.0 h1:/yfVAwtPmdx45aQBoXQImeY7sOIEr7IXlImRMBOZ7GQ=
@@ -681,7 +681,7 @@ github.com/ulikunitz/xz v0.5.6/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4A
 github.com/ulikunitz/xz v0.5.7/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/ulikunitz/xz v0.5.10 h1:t92gobL9l3HE202wg3rlk19F6X+JOxl9BBrCCMYEYd8=
 github.com/ulikunitz/xz v0.5.10/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
-github.com/urfave/cli v1.22.4/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
+github.com/urfave/cli v1.22.9/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/xdg-go/stringprep v1.0.2 h1:6iq84/ryjjeRmMJwxutI51F2GIPlP5BfTvXHeYjyhBc=
 github.com/xdg-go/stringprep v1.0.2/go.mod h1:8F9zXuvzgwmyT5DUm4GUfZGDdT3W+LCvS6+da4O5kxM=
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 h1:nIPpBwaJSVYIxUFsDv3M8ofmx9yWTog9BfvIu0q41lo=

--- a/macaroon_service.go
+++ b/macaroon_service.go
@@ -11,20 +11,15 @@ import (
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/lightningnetwork/lnd/keychain"
-	"github.com/lightningnetwork/lnd/kvdb"
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/macaroons"
 	"github.com/lightningnetwork/lnd/rpcperms"
-	"go.etcd.io/bbolt"
 	"google.golang.org/grpc"
 	"gopkg.in/macaroon-bakery.v2/bakery"
 	"gopkg.in/macaroon-bakery.v2/bakery/checkers"
 )
 
 const (
-	// defaultDBName is the default macaroon db name.
-	defaultDBName = "macaroons.db"
-
 	// defaultDBTimeout is the default timeout to be used for the
 	// macaroon db connection.
 	defaultDBTimeout = 5 * time.Second
@@ -58,22 +53,16 @@ var (
 type MacaroonService struct {
 	cfg *MacaroonServiceConfig
 
-	db kvdb.Backend
-
 	*macaroons.Service
 }
 
 // MacaroonServiceConfig holds configuration values used by the MacaroonService.
 type MacaroonServiceConfig struct {
-	// DBPath is the path to where the macaroon db file will be stored.
-	DBPath string
-
-	// DBFile is the name of the macaroon db.
-	DBFileName string
-
-	// DBTimeout is the maximum time we wait for the bbolt database to be
-	// opened.
-	DBTimeout time.Duration
+	// RootKeyStorage is an implementation of the main
+	// bakery.RootKeyStorage interface. This implementation may also
+	// concurrenlty implement the larger macaroons.ExtendedRootKeyStore
+	// interface as well.
+	RootKeyStore bakery.RootKeyStore
 
 	// MacaroonLocation is the value used for a macaroons' "Location" field.
 	MacaroonLocation string
@@ -122,22 +111,8 @@ type MacaroonServiceConfig struct {
 // MacaroonService object accordingly.
 func NewMacaroonService(cfg *MacaroonServiceConfig) (*MacaroonService, error) {
 	// Validate config.
-	if cfg.DBPath == "" {
-		return nil, errors.New("no macaroon db path provided")
-	}
-
 	if cfg.MacaroonLocation == "" {
 		return nil, errors.New("no macaroon location provided")
-	}
-
-	if cfg.DBFileName == "" {
-		cfg.DBFileName = defaultDBName
-	}
-
-	if cfg.DBTimeout == 0 {
-		cfg.DBTimeout = defaultDBTimeout
-	} else if cfg.DBTimeout < 0 {
-		return nil, errors.New("can't have a negative db timeout")
 	}
 
 	if cfg.RPCTimeout == 0 {
@@ -159,6 +134,11 @@ func NewMacaroonService(cfg *MacaroonServiceConfig) (*MacaroonService, error) {
 		return &ms, nil
 	}
 
+	_, extendedKeyStore := ms.cfg.RootKeyStore.(macaroons.ExtendedRootKeyStore)
+	if !extendedKeyStore {
+		return &ms, nil
+	}
+
 	if cfg.LndClient == nil || cfg.EphemeralKey == nil ||
 		cfg.KeyLocator == nil {
 
@@ -170,32 +150,13 @@ func NewMacaroonService(cfg *MacaroonServiceConfig) (*MacaroonService, error) {
 	return &ms, nil
 }
 
-// Start starts the macaroon validation service, creates or unlocks the macaroon
-// database and, if we are not in stateless mode, creates the default macaroon
-// if it doesn't exist yet.
+// Start starts the macaroon validation service, creates or unlocks the
+// macaroon database and, if we are not in stateless mode, creates the default
+// macaroon if it doesn't exist yet.
 func (ms *MacaroonService) Start() error {
-	// Open the database.
-	var err error
-	ms.db, err = kvdb.GetBoltBackend(&kvdb.BoltBackendConfig{
-		DBPath:     ms.cfg.DBPath,
-		DBFileName: ms.cfg.DBFileName,
-		DBTimeout:  ms.cfg.DBTimeout,
-	})
-	if err == bbolt.ErrTimeout {
-		return fmt.Errorf("error while trying to open %s/%s: "+
-			"timed out after %v when trying to obtain exclusive "+
-			"lock - make sure no other daemon process "+
-			"(standalone or embedded in lightning-terminal) is "+
-			"trying to access this db", ms.cfg.DBPath,
-			ms.cfg.DBFileName, ms.cfg.DBTimeout)
-	}
-	if err != nil {
-		return fmt.Errorf("unable to load macaroon db: %v", err)
-	}
-
 	// Create the macaroon authentication/authorization service.
 	service, err := macaroons.NewService(
-		ms.db, ms.cfg.MacaroonLocation, ms.cfg.StatelessInit,
+		ms.cfg.RootKeyStore, ms.cfg.MacaroonLocation, ms.cfg.StatelessInit,
 		ms.cfg.Checkers...,
 	)
 	if err != nil {
@@ -203,7 +164,13 @@ func (ms *MacaroonService) Start() error {
 	}
 	ms.Service = service
 
+	_, extendedKeyStore := ms.cfg.RootKeyStore.(macaroons.ExtendedRootKeyStore)
 	switch {
+	// The passed root key store doesn't use the extended interface, so we
+	// can skip everything below.
+	case !extendedKeyStore:
+		break
+
 	case len(ms.cfg.DBPassword) != 0:
 		// If a non-empty DB password was provided, then use this
 		// directly to try and unlock the db.
@@ -310,9 +277,12 @@ func (ms *MacaroonService) Stop() error {
 		shutdownErr = err
 	}
 
-	if err := ms.db.Close(); err != nil {
-		log.Errorf("Error closing macaroon DB: %v", err)
-		shutdownErr = err
+	rks := ms.cfg.RootKeyStore
+	if eRKS, ok := rks.(macaroons.ExtendedRootKeyStore); ok {
+		if err := eRKS.Close(); err != nil {
+			log.Errorf("Error closing macaroon DB: %v", err)
+			shutdownErr = err
+		}
 	}
 
 	return shutdownErr

--- a/macaroon_service_test.go
+++ b/macaroon_service_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/lightningnetwork/lnd/keychain"
-	"github.com/lightningnetwork/lnd/kvdb"
 	"github.com/lightningnetwork/lnd/macaroons"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/macaroon-bakery.v2/bakery"
@@ -25,13 +24,9 @@ func TestMacaroonServiceMigration(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll(tempDirPath)
 
-	db, err := kvdb.GetBoltBackend(&kvdb.BoltBackendConfig{
-		DBPath:     tempDirPath,
-		DBFileName: "macaroons.db",
-		DBTimeout:  defaultDBTimeout,
-	})
-	require.NoError(t, err)
-	rks, err := macaroons.NewRootKeyStorage(db)
+	rks, err := NewBoltMacaroonStore(
+		tempDirPath, "macaroons.db", defaultDBTimeout,
+	)
 	require.NoError(t, err)
 
 	// The initial config we will use has an empty DB password.

--- a/macaroon_service_test.go
+++ b/macaroon_service_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/lightningnetwork/lnd/kvdb"
 	"github.com/lightningnetwork/lnd/macaroons"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/macaroon-bakery.v2/bakery"
 )
 
 // TestMacaroonServiceMigration tests that a client that was using a macaroon
@@ -24,14 +25,21 @@ func TestMacaroonServiceMigration(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll(tempDirPath)
 
+	db, err := kvdb.GetBoltBackend(&kvdb.BoltBackendConfig{
+		DBPath:     tempDirPath,
+		DBFileName: "macaroons.db",
+		DBTimeout:  defaultDBTimeout,
+	})
+	require.NoError(t, err)
+	rks, err := macaroons.NewRootKeyStorage(db)
+	require.NoError(t, err)
+
 	// The initial config we will use has an empty DB password.
 	cfg := &MacaroonServiceConfig{
-		DBPath:           tempDirPath,
-		DBFileName:       "macaroons.db",
-		DBTimeout:        defaultDBTimeout,
 		MacaroonLocation: "testLocation",
 		MacaroonPath:     tempDirPath,
 		DBPassword:       []byte{},
+		RootKeyStore:     rks,
 	}
 
 	// Create a new macaroon service with an empty password.
@@ -90,25 +98,16 @@ func TestMacaroonServiceMigration(t *testing.T) {
 
 type testMacaroonService struct {
 	*macaroons.Service
-	db kvdb.Backend
+	rks bakery.RootKeyStore
 }
 
 func createTestService(cfg *MacaroonServiceConfig) (*testMacaroonService,
 	error) {
 
-	db, err := kvdb.GetBoltBackend(&kvdb.BoltBackendConfig{
-		DBPath:     cfg.DBPath,
-		DBFileName: cfg.DBFileName,
-		DBTimeout:  cfg.DBTimeout,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("unable to load macaroon db: "+
-			"%v", err)
-	}
-
 	// Create the macaroon authentication/authorization service.
 	service, err := macaroons.NewService(
-		db, cfg.MacaroonLocation, cfg.StatelessInit, cfg.Checkers...,
+		cfg.RootKeyStore, cfg.MacaroonLocation, cfg.StatelessInit,
+		cfg.Checkers...,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("unable to set up macaroon "+
@@ -117,14 +116,16 @@ func createTestService(cfg *MacaroonServiceConfig) (*testMacaroonService,
 
 	return &testMacaroonService{
 		Service: service,
-		db:      db,
+		rks:     cfg.RootKeyStore,
 	}, nil
 }
 
 func (s *testMacaroonService) stop() error {
 	var returnErr error
-	if err := s.db.Close(); err != nil {
-		returnErr = err
+	if eRKS, ok := s.rks.(macaroons.ExtendedRootKeyStore); ok {
+		if err := eRKS.Close(); err != nil {
+			returnErr = err
+		}
 	}
 
 	if err := s.Close(); err != nil {

--- a/testdata/permissions.json
+++ b/testdata/permissions.json
@@ -64,6 +64,14 @@
                 }
             ]
         },
+        "/devrpc.Dev/ImportGraph": {
+            "permissions": [
+                {
+                    "entity": "offchain",
+                    "action": "write"
+                }
+            ]
+        },
         "/invoicesrpc.Invoices/AddHoldInvoice": {
             "permissions": [
                 {
@@ -73,6 +81,14 @@
             ]
         },
         "/invoicesrpc.Invoices/CancelInvoice": {
+            "permissions": [
+                {
+                    "entity": "invoices",
+                    "action": "write"
+                }
+            ]
+        },
+        "/invoicesrpc.Invoices/LookupInvoiceV2": {
             "permissions": [
                 {
                     "entity": "invoices",
@@ -117,6 +133,18 @@
                 {
                     "entity": "macaroon",
                     "action": "generate"
+                }
+            ]
+        },
+        "/lnrpc.Lightning/BatchOpenChannel": {
+            "permissions": [
+                {
+                    "entity": "onchain",
+                    "action": "write"
+                },
+                {
+                    "entity": "offchain",
+                    "action": "write"
                 }
             ]
         },
@@ -204,6 +232,14 @@
             "permissions": [
                 {
                     "entity": "macaroon",
+                    "action": "write"
+                }
+            ]
+        },
+        "/lnrpc.Lightning/DeletePayment": {
+            "permissions": [
+                {
+                    "entity": "offchain",
                     "action": "write"
                 }
             ]
@@ -468,6 +504,14 @@
                 }
             ]
         },
+        "/lnrpc.Lightning/SendCustomMessage": {
+            "permissions": [
+                {
+                    "entity": "offchain",
+                    "action": "write"
+                }
+            ]
+        },
         "/lnrpc.Lightning/SendMany": {
             "permissions": [
                 {
@@ -548,6 +592,14 @@
                 }
             ]
         },
+        "/lnrpc.Lightning/SubscribeCustomMessages": {
+            "permissions": [
+                {
+                    "entity": "offchain",
+                    "action": "read"
+                }
+            ]
+        },
         "/lnrpc.Lightning/SubscribeInvoices": {
             "permissions": [
                 {
@@ -604,6 +656,62 @@
                 }
             ]
         },
+        "/neutrinorpc.NeutrinoKit/AddPeer": {
+            "permissions": [
+                {
+                    "entity": "peers",
+                    "action": "write"
+                }
+            ]
+        },
+        "/neutrinorpc.NeutrinoKit/DisconnectPeer": {
+            "permissions": [
+                {
+                    "entity": "peers",
+                    "action": "write"
+                }
+            ]
+        },
+        "/neutrinorpc.NeutrinoKit/GetBlock": {
+            "permissions": [
+                {
+                    "entity": "onchain",
+                    "action": "read"
+                }
+            ]
+        },
+        "/neutrinorpc.NeutrinoKit/GetBlockHeader": {
+            "permissions": [
+                {
+                    "entity": "onchain",
+                    "action": "read"
+                }
+            ]
+        },
+        "/neutrinorpc.NeutrinoKit/GetCFilter": {
+            "permissions": [
+                {
+                    "entity": "onchain",
+                    "action": "read"
+                }
+            ]
+        },
+        "/neutrinorpc.NeutrinoKit/IsBanned": {
+            "permissions": [
+                {
+                    "entity": "info",
+                    "action": "read"
+                }
+            ]
+        },
+        "/neutrinorpc.NeutrinoKit/Status": {
+            "permissions": [
+                {
+                    "entity": "info",
+                    "action": "read"
+                }
+            ]
+        },
         "/routerrpc.Router/BuildRoute": {
             "permissions": [
                 {
@@ -613,6 +721,14 @@
             ]
         },
         "/routerrpc.Router/EstimateRouteFee": {
+            "permissions": [
+                {
+                    "entity": "offchain",
+                    "action": "read"
+                }
+            ]
+        },
+        "/routerrpc.Router/GetMissionControlConfig": {
             "permissions": [
                 {
                     "entity": "offchain",
@@ -684,6 +800,14 @@
                 }
             ]
         },
+        "/routerrpc.Router/SetMissionControlConfig": {
+            "permissions": [
+                {
+                    "entity": "offchain",
+                    "action": "write"
+                }
+            ]
+        },
         "/routerrpc.Router/SubscribeHtlcEvents": {
             "permissions": [
                 {
@@ -708,15 +832,15 @@
                 }
             ]
         },
-	"/routerrpc.Router/QueryMissionControl": {
+        "/routerrpc.Router/UpdateChanStatus": {
             "permissions": [
                 {
                     "entity": "offchain",
-                    "action": "read"
+                    "action": "write"
                 }
             ]
         },
-	"/routerrpc.Router/XImportMissionControl": {
+        "/routerrpc.Router/XImportMissionControl": {
             "permissions": [
                 {
                     "entity": "offchain",
@@ -748,7 +872,7 @@
                 }
             ]
         },
-        "/signrpc.Signer/SignMessage": {
+        "/signrpc.Signer/MuSig2Cleanup": {
             "permissions": [
                 {
                     "entity": "signer",
@@ -756,27 +880,19 @@
                 }
             ]
         },
-        "/signrpc.Signer/SignOutputRaw": {
+        "/signrpc.Signer/MuSig2CombineKeys": {
+            "permissions": [
+                {
+                    "entity": "signer",
+                    "action": "read"
+                }
+            ]
+        },
+        "/signrpc.Signer/MuSig2CombineSig": {
             "permissions": [
                 {
                     "entity": "signer",
                     "action": "generate"
-                }
-            ]
-        },
-        "/signrpc.Signer/VerifyMessage": {
-            "permissions": [
-                {
-                    "entity": "signer",
-                    "action": "read"
-                }
-            ]
-        },
-        "/signrpc.Signer/VerifyMessage": {
-            "permissions": [
-                {
-                    "entity": "signer",
-                    "action": "read"
                 }
             ]
         },
@@ -804,7 +920,7 @@
                 }
             ]
         },
-        "/signrpc.Signer/MuSig2CombineSig": {
+        "/signrpc.Signer/SignMessage": {
             "permissions": [
                 {
                     "entity": "signer",
@@ -812,11 +928,19 @@
                 }
             ]
         },
-        "/signrpc.Signer/MuSig2Cleanup": {
+        "/signrpc.Signer/SignOutputRaw": {
             "permissions": [
                 {
                     "entity": "signer",
                     "action": "generate"
+                }
+            ]
+        },
+        "/signrpc.Signer/VerifyMessage": {
+            "permissions": [
+                {
+                    "entity": "signer",
+                    "action": "read"
                 }
             ]
         },
@@ -876,7 +1000,15 @@
                 }
             ]
         },
-        "/walletrpc.WalletKit/SignPsbt": {
+        "/walletrpc.WalletKit/ImportAccount": {
+            "permissions": [
+                {
+                    "entity": "onchain",
+                    "action": "write"
+                }
+            ]
+        },
+        "/walletrpc.WalletKit/ImportPublicKey": {
             "permissions": [
                 {
                     "entity": "onchain",
@@ -897,6 +1029,22 @@
                 {
                     "entity": "onchain",
                     "action": "write"
+                }
+            ]
+        },
+        "/walletrpc.WalletKit/ListAccounts": {
+            "permissions": [
+                {
+                    "entity": "onchain",
+                    "action": "read"
+                }
+            ]
+        },
+        "/walletrpc.WalletKit/ListLeases": {
+            "permissions": [
+                {
+                    "entity": "onchain",
+                    "action": "read"
                 }
             ]
         },
@@ -956,19 +1104,11 @@
                 }
             ]
         },
-		"/walletrpc.WalletKit/ListAccounts": {
-			"permissions":[
-				{
-					"entity": "onchain",
-					"action": "read"
-				}
-			]
-		},
-        "/watchtowerrpc.Watchtower/GetInfo": {
+        "/walletrpc.WalletKit/SignPsbt": {
             "permissions": [
                 {
-                    "entity": "info",
-                    "action": "read"
+                    "entity": "onchain",
+                    "action": "write"
                 }
             ]
         },


### PR DESCRIPTION
In this commit we update to the new version of the macaroons package
that doesn't require the caller to use the default implementation for
the root key store. Instead, the caller can pass in an implementation,
and based on that we'll change our behavior.

#### Pull Request Checklist

- [ ] PR is opened against correct version branch.
- [ ] Version compatibility matrix in the README and minimal required version
      in `lnd_services.go` are updated.
- [ ] Update `macaroon_recipes.go` if your PR adds a new method that is called
  differently than the RPC method it invokes.
