### PR TITLE
Fix compatibility issues with Pool

### DIFF
--- a/macaroon_recipes.go
+++ b/macaroon_recipes.go
@@ -39,6 +39,7 @@ var (
 		"InterceptHtlcs":         "HtlcInterceptor",
 		"ImportMissionControl":   "XImportMissionControl",
 		"EstimateFeeRate":        "EstimateFee",
+		"EstimateFeeToP2WSH":     "EstimateFee",
 	}
 )
 

--- a/signer_client.go
+++ b/signer_client.go
@@ -67,7 +67,7 @@ type SignerClient interface {
 	// session. It returns a boolean indicating whether we have all of our
 	// nonces present.
 	MuSig2RegisterNonces(ctx context.Context, sessionID [32]byte,
-		nonces [][musig2.PubNonceSize]byte) (bool, error)
+		nonces [][66]byte) (bool, error)
 
 	// MuSig2Sign creates a partial signature for the 32 byte SHA256 digest
 	// of a message. This can only be called once all public nonces have
@@ -505,7 +505,7 @@ func (s *signerClient) MuSig2CreateSession(ctx context.Context,
 // MuSig2RegisterNonces registers additional public nonces for a musig2 session.
 // It returns a boolean indicating whether we have all of our nonces present.
 func (s *signerClient) MuSig2RegisterNonces(ctx context.Context,
-	sessionID [32]byte, nonces [][musig2.PubNonceSize]byte) (bool, error) {
+	sessionID [32]byte, nonces [][66]byte) (bool, error) {
 
 	req := &signrpc.MuSig2RegisterNoncesRequest{
 		SessionId:               sessionID[:],


### PR DESCRIPTION
#### Pull Request Checklist

Fixes a problem found with the mocking library we use in Pool. And we also add back the `EstimateFeeToP2WSH` convenience method, since that's still used in some projects.

- [X] PR is opened against correct version branch.
- [ ] Version compatibility matrix in the README and minimal required version
      in `lnd_services.go` are updated.
- [X] Update `macaroon_recipes.go` if your PR adds a new method that is called
  differently than the RPC method it invokes.
