### PR TITLE
Include invoice description hash when adding invoice via RPC client

### DIFF
--- a/lightning_client.go
+++ b/lightning_client.go
@@ -1364,11 +1364,12 @@ func (s *lightningClient) AddInvoice(ctx context.Context,
 	defer cancel()
 
 	rpcIn := &lnrpc.Invoice{
-		Memo:       in.Memo,
-		ValueMsat:  int64(in.Value),
-		Expiry:     in.Expiry,
-		CltvExpiry: in.CltvExpiry,
-		Private:    true,
+		Memo:            in.Memo,
+		ValueMsat:       int64(in.Value),
+		DescriptionHash: in.DescriptionHash,
+		Expiry:          in.Expiry,
+		CltvExpiry:      in.CltvExpiry,
+		Private:         true,
 	}
 
 	if in.Preimage != nil {

--- a/lightning_client_test.go
+++ b/lightning_client_test.go
@@ -1,0 +1,172 @@
+package lndclient
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/lightningnetwork/lnd/lnrpc"
+	"github.com/lightningnetwork/lnd/lnrpc/invoicesrpc"
+	"github.com/lightningnetwork/lnd/lntypes"
+	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+// addInvoiceArg records the args used in a call to mockRPCClient.AddInvoice.
+type addInvoiceArg struct {
+	in   *lnrpc.Invoice
+	opts []grpc.CallOption
+}
+
+// mockRPCClient implements lnrpc.LightningClient with dynamic method
+// implementations and call spying.
+type mockRPCClient struct {
+	lnrpc.LightningClient
+
+	addInvoice func(in *lnrpc.Invoice, opts ...grpc.CallOption) (
+		*lnrpc.AddInvoiceResponse, error)
+	addInvoiceArgs []addInvoiceArg
+}
+
+func (m *mockRPCClient) AddInvoice(ctx context.Context, in *lnrpc.Invoice,
+	opts ...grpc.CallOption) (*lnrpc.AddInvoiceResponse, error) {
+
+	m.addInvoiceArgs = append(m.addInvoiceArgs, addInvoiceArg{
+		in:   in,
+		opts: opts,
+	})
+
+	return m.addInvoice(in, opts...)
+}
+
+// TestLightningClientAddInvoice ensures that adding an invoice via
+// lightningClient is completed as expected.
+func TestLightningClientAddInvoice(t *testing.T) {
+	// Define constants / fixtures.
+	var validPreimage lntypes.Preimage
+	copy(validPreimage[:], "valid preimage")
+	var validRHash lntypes.Hash
+	copy(validRHash[:], "valid hash")
+	validAddInvoiceData := &invoicesrpc.AddInvoiceData{
+		Memo:            "fake memo",
+		Preimage:        &validPreimage,
+		Hash:            &validRHash,
+		Value:           lnwire.MilliSatoshi(500000),
+		DescriptionHash: []byte("fake 32 byte hash"),
+		Expiry:          123,
+		CltvExpiry:      456,
+	}
+
+	validInvoice := &lnrpc.Invoice{
+		Memo:            validAddInvoiceData.Memo,
+		RPreimage:       validAddInvoiceData.Preimage[:],
+		RHash:           validAddInvoiceData.Hash[:],
+		ValueMsat:       int64(validAddInvoiceData.Value),
+		DescriptionHash: validAddInvoiceData.DescriptionHash,
+		Expiry:          validAddInvoiceData.Expiry,
+		CltvExpiry:      validAddInvoiceData.CltvExpiry,
+		Private:         true,
+	}
+
+	validPayReq := "a valid pay req"
+	validResp := &lnrpc.AddInvoiceResponse{
+		RHash:          validRHash[:],
+		PaymentRequest: validPayReq,
+	}
+
+	validAddInvoiceArgs := []addInvoiceArg{
+		{in: validInvoice},
+	}
+
+	validAddInvoice := func(in *lnrpc.Invoice, opts ...grpc.CallOption) (
+		*lnrpc.AddInvoiceResponse, error) {
+		return validResp, nil
+	}
+
+	errorAddInvoice := func(in *lnrpc.Invoice, opts ...grpc.CallOption) (
+		*lnrpc.AddInvoiceResponse, error) {
+		return nil, errors.New("error")
+	}
+
+	// Set up the test structure.
+	type expect struct {
+		addInvoiceArgs []addInvoiceArg
+		hash           lntypes.Hash
+		payRequest     string
+		wantErr        bool
+	}
+
+	type testCase struct {
+		name    string
+		client  mockRPCClient
+		invoice *invoicesrpc.AddInvoiceData
+		expect  expect
+	}
+
+	// Run through the test cases.
+	tests := []testCase{
+		{
+			name: "happy path",
+			client: mockRPCClient{
+				addInvoice: validAddInvoice,
+			},
+			invoice: validAddInvoiceData,
+			expect: expect{
+				addInvoiceArgs: validAddInvoiceArgs,
+				hash:           validRHash,
+				payRequest:     validPayReq,
+			},
+		}, {
+			name: "rpc client error",
+			client: mockRPCClient{
+				addInvoice: errorAddInvoice,
+			},
+			invoice: validAddInvoiceData,
+			expect: expect{
+				addInvoiceArgs: validAddInvoiceArgs,
+				wantErr:        true,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			ln := lightningClient{
+				client: &test.client,
+			}
+
+			hash, payRequest, err := ln.AddInvoice(
+				context.Background(), test.invoice,
+			)
+
+			// Check if an error (or no error) was received as
+			// expected.
+			if test.expect.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			// Check if the expected hash was returned.
+			require.Equal(
+				t, hash, test.expect.hash,
+				"received unexpected hash",
+			)
+
+			// Check if the expected invoice was returned.
+			require.Equal(
+				t, payRequest, test.expect.payRequest,
+				"received unexpected payment request",
+			)
+
+			// Check if the expected args were passed to the RPC
+			// client call.
+			require.Equal(t, test.client.addInvoiceArgs,
+				test.expect.addInvoiceArgs,
+				"rpc client call was not made as expected",
+			)
+		})
+	}
+}


### PR DESCRIPTION
This PR modifies `lightningClient.AddInvoice` to pass along `DescriptionHash` to the underlying `lnrpc.LightningClient` `AddInvoice` call, as it was previously missing.

For example, previously the behaviour was:
```go
// client is lndclient.LightningClient
_, invStr, _ := client.AddInvoice(ctx, invoicesrpc.AddInvoiceData{
    DescriptionHash: hashedDesc,
    Value: lnwire.MilliSatoshi(100000),
})

decoded, _ := zpay32.Decode(bolt11, chainParams)

// Prints ""
fmt.Printf("%q", decoded.Description)
// Prints nil
fmt.Printf("%v", decoded.DescriptionHash)
```

I didn't add any of the other fields that are _**also**_ not currently passed along from the [AddInvoiceData](https://pkg.go.dev/github.com/lightningnetwork/lnd/lnrpc/invoicesrpc@v0.14.3-beta#AddInvoiceData) to the [lnrpc.Invoice](https://pkg.go.dev/github.com/lightningnetwork/lnd/lnrpc@v0.14.3-beta#Invoice) struct, as wasn't sure if that was an intentional decision. (AFAIK this includes `FallbackAddr`; `Private`, which is currently hardcoded to `true`; and `Amp`/`IsAmp`).

This PR also includes some initial (small) tests for the `lightning_client.go` file, starting with the `AddInvoice` method that is modified here. I figured it could be useful to ensure the underlying call is wrapped as expected, but can remove it if it doesn't seem particularly useful.

Additional context can be found in the LND Developer Community Slack (see [here](https://lightningcommunity.slack.com/archives/C6BDA6DGE/p1655260353517389) and [here](https://lightningcommunity.slack.com/archives/C6BDA6DGE/p1655266993775639)).

#### Pull Request Checklist

- [x] PR is opened against correct version branch.
- [x] Version compatibility matrix in the README and minimal required version
      in `lnd_services.go` are updated.
- [x] Update `macaroon_recipes.go` if your PR adds a new method that is called
  differently than the RPC method it invokes.
