### PR TITLE
router_client: add UpdateChanStatus to router interface

### DIFF
--- a/router_client.go
+++ b/router_client.go
@@ -67,6 +67,11 @@ type RouterClient interface {
 
 	// ResetMissionControl resets the Mission Control state of lnd.
 	ResetMissionControl(ctx context.Context) error
+
+	// UpdateChanStatus attempts to manually set the state of a channel
+	// (enabled, disabled, or auto).
+	UpdateChanStatus(ctx context.Context,
+		channel *wire.OutPoint, action routerrpc.ChanStatusAction) error
 }
 
 // PaymentStatus describe the state of a payment.

--- a/testdata/permissions.json
+++ b/testdata/permissions.json
@@ -724,6 +724,14 @@
                 }
             ]
         },
+        "/routerrpc.Router/UpdateChanStatus": {
+            "permissions": [
+                {
+                    "entity": "offchain",
+                    "action": "write"
+                }
+            ]
+        },
         "/signrpc.Signer/ComputeInputScript": {
             "permissions": [
                 {


### PR DESCRIPTION
Unfortunately I didn't add UpdateChanStatus to the router interface in the last commit.

I tested the rpc call with a local running lnd 0.15.0.