### PR TITLE
lndclient: expose new option to recv the block w/ a conf ntfn

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1
 	github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f
 	github.com/btcsuite/btcwallet/wtxmgr v1.5.0
-	github.com/lightningnetwork/lnd v0.15.0-beta.rc6.0.20220727000530-fec8fd9c63dc
+	github.com/lightningnetwork/lnd v0.15.0-beta.rc6.0.20220810115249-17014b592e0f
 	github.com/lightningnetwork/lnd/kvdb v1.3.1
 	github.com/stretchr/testify v1.7.1
 	google.golang.org/grpc v1.38.0
@@ -103,6 +103,7 @@ require (
 	github.com/sirupsen/logrus v1.7.0 // indirect
 	github.com/soheilhy/cmux v0.1.5 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/stretchr/objx v0.2.0 // indirect
 	github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 // indirect
 	github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802 // indirect
 	github.com/ulikunitz/xz v0.5.10 // indirect

--- a/go.sum
+++ b/go.sum
@@ -497,8 +497,8 @@ github.com/lightninglabs/neutrino v0.14.2/go.mod h1:OICUeTCn+4Tu27YRJIpWvvqySxx4
 github.com/lightninglabs/protobuf-hex-display v1.4.3-hex-display/go.mod h1:2oKOBU042GKFHrdbgGiKax4xVrFiZu51lhacUZQ9MnE=
 github.com/lightningnetwork/lightning-onion v1.0.2-0.20220211021909-bb84a1ccb0c5 h1:TkKwqFcQTGYoI+VEqyxA8rxpCin8qDaYX0AfVRinT3k=
 github.com/lightningnetwork/lightning-onion v1.0.2-0.20220211021909-bb84a1ccb0c5/go.mod h1:7dDx73ApjEZA0kcknI799m2O5kkpfg4/gr7N092ojNo=
-github.com/lightningnetwork/lnd v0.15.0-beta.rc6.0.20220727000530-fec8fd9c63dc h1:5lh6f3xjIqQXU2hv3qllqzkasI9oi2HEtZmvgbwFa8E=
-github.com/lightningnetwork/lnd v0.15.0-beta.rc6.0.20220727000530-fec8fd9c63dc/go.mod h1:sa+hYajDLPn2I2zG99ylXOCF3yK3AQqFu0M0v97vh08=
+github.com/lightningnetwork/lnd v0.15.0-beta.rc6.0.20220810115249-17014b592e0f h1:LSKR7f6YqDMtDgCVUruiqozjXJiVtSySDTDVesjmRqY=
+github.com/lightningnetwork/lnd v0.15.0-beta.rc6.0.20220810115249-17014b592e0f/go.mod h1:sa+hYajDLPn2I2zG99ylXOCF3yK3AQqFu0M0v97vh08=
 github.com/lightningnetwork/lnd/cert v1.1.1/go.mod h1:1P46svkkd73oSoeI4zjkVKgZNwGq8bkGuPR8z+5vQUs=
 github.com/lightningnetwork/lnd/clock v1.0.1/go.mod h1:KnQudQ6w0IAMZi1SgvecLZQZ43ra2vpDNj7H/aasemg=
 github.com/lightningnetwork/lnd/clock v1.1.0 h1:/yfVAwtPmdx45aQBoXQImeY7sOIEr7IXlImRMBOZ7GQ=

--- a/tx_utils.go
+++ b/tx_utils.go
@@ -35,6 +35,17 @@ func decodeTx(rawTx []byte) (*wire.MsgTx, error) {
 	return &tx, nil
 }
 
+// decodeBlock decodes a raw block into a struct.
+func decodeBlock(rawBlock []byte) (*wire.MsgBlock, error) {
+	var block wire.MsgBlock
+	err := block.Deserialize(bytes.NewReader(rawBlock))
+	if err != nil {
+		return nil, err
+	}
+
+	return &block, nil
+}
+
 // NewOutpointFromStr creates an outpoint from a string with the format
 // txid:index.
 func NewOutpointFromStr(outpoint string) (*wire.OutPoint, error) {


### PR DESCRIPTION
In order to not break all the other callers, we opt to more or less copy
over the functional options added on the lnd side of things. We would be
able to just use the existing opts, but the includeBlock field is
private (as it should be imo).
