### PR TITLE
lndclient: include chan status flags on listchannels

### DIFF
--- a/lightning_client.go
+++ b/lightning_client.go
@@ -292,6 +292,10 @@ type ChannelInfo struct {
 	// online over its lifetime.
 	Uptime time.Duration
 
+	// ChanStatusFlags is a set of flags showing the current state of the
+	// channel.
+	ChanStatusFlags string
+
 	// TotalSent is the total amount sent over this channel for our own
 	// payments.
 	TotalSent btcutil.Amount
@@ -350,6 +354,7 @@ func (s *lightningClient) newChannelInfo(channel *lnrpc.Channel) (*ChannelInfo,
 		UnsettledBalance: btcutil.Amount(channel.UnsettledBalance),
 		Initiator:        channel.Initiator,
 		Private:          channel.Private,
+		ChanStatusFlags:  channel.ChanStatusFlags,
 		NumPendingHtlcs:  len(channel.PendingHtlcs),
 		TotalSent:        btcutil.Amount(channel.TotalSatoshisSent),
 		TotalReceived:    btcutil.Amount(channel.TotalSatoshisReceived),


### PR DESCRIPTION
#### Pull Request Checklist

- [x] PR is opened against correct version branch.
- [x] Version compatibility matrix in the README and minimal required version
      in `lnd_services.go` are updated.
- [x] Update `macaroon_recipes.go` if your PR adds a new method that is called
  differently than the RPC method it invokes.

#### Description

This is a minor PR that introduces the `chan_status_flags` field of lnd API's [channels](https://api.lightning.community/#lnrpc-channel) to `lndclient`'s `ChannelInfo`.