### PR TITLE
walletkit: add ImportTaprootScript RPC

### DIFF
--- a/chainnotifier_client.go
+++ b/chainnotifier_client.go
@@ -30,7 +30,7 @@ func defaultNotifierOptions() *notifierOptions {
 // events received from the notifier.
 type NotifierOption func(*notifierOptions)
 
-// WithIncludeBlock is an optional argument that allows the calelr to specify
+// WithIncludeBlock is an optional argument that allows the caller to specify
 // that the block that mined a transaction should be included in the response.
 func WithIncludeBlock() NotifierOption {
 	return func(o *notifierOptions) {

--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,9 @@ require (
 	github.com/btcsuite/btcd/btcutil/psbt v1.1.5
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1
 	github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f
+	github.com/btcsuite/btcwallet v0.15.2-0.20220804001213-5aafe4789850
 	github.com/btcsuite/btcwallet/wtxmgr v1.5.0
-	github.com/lightningnetwork/lnd v0.15.0-beta.rc6.0.20220810115249-17014b592e0f
+	github.com/lightningnetwork/lnd v0.15.0-beta.rc6.0.20220825081330-cf9a9864cf25
 	github.com/lightningnetwork/lnd/kvdb v1.3.1
 	github.com/stretchr/testify v1.7.1
 	google.golang.org/grpc v1.38.0
@@ -21,7 +22,6 @@ require (
 	github.com/aead/siphash v1.0.1 // indirect
 	github.com/andybalholm/brotli v1.0.3 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/btcsuite/btcwallet v0.15.1 // indirect
 	github.com/btcsuite/btcwallet/wallet/txauthor v1.2.3 // indirect
 	github.com/btcsuite/btcwallet/wallet/txrules v1.2.0 // indirect
 	github.com/btcsuite/btcwallet/wallet/txsizes v1.1.0 // indirect
@@ -85,7 +85,7 @@ require (
 	github.com/lightningnetwork/lnd/queue v1.1.0 // indirect
 	github.com/lightningnetwork/lnd/ticker v1.1.0 // indirect
 	github.com/lightningnetwork/lnd/tlv v1.0.3 // indirect
-	github.com/lightningnetwork/lnd/tor v1.0.1 // indirect
+	github.com/lightningnetwork/lnd/tor v1.0.2 // indirect
 	github.com/ltcsuite/ltcd v0.0.0-20190101042124-f37f8bf35796 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
 	github.com/mholt/archiver/v3 v3.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -80,7 +80,6 @@ github.com/btcsuite/btcd v0.23.1/go.mod h1:0QJIIN1wwIXF/3G/m87gIwGniDMDQqjVn4SZg
 github.com/btcsuite/btcd/btcec/v2 v2.1.0/go.mod h1:2VzYrv4Gm4apmbVVsSq5bqf1Ec8v56E48Vt0Y/umPgA=
 github.com/btcsuite/btcd/btcec/v2 v2.1.1/go.mod h1:ctjw4H1kknNJmRN4iP1R7bTQ+v3GJkZBd6mui8ZsAZE=
 github.com/btcsuite/btcd/btcec/v2 v2.1.3/go.mod h1:ctjw4H1kknNJmRN4iP1R7bTQ+v3GJkZBd6mui8ZsAZE=
-github.com/btcsuite/btcd/btcec/v2 v2.2.0/go.mod h1:U7MHm051Al6XmscBQ0BoNydpOTsFAn707034b5nY8zU=
 github.com/btcsuite/btcd/btcec/v2 v2.2.1 h1:xP60mv8fvp+0khmrN0zTdPC3cNm24rfeE6lh2R/Yv3E=
 github.com/btcsuite/btcd/btcec/v2 v2.2.1/go.mod h1:9/CSmJxmuvqzX9Wh2fXMWToLOHhPd11lSPuIupwTkI8=
 github.com/btcsuite/btcd/btcutil v1.0.0/go.mod h1:Uoxwv0pqYWhD//tfTiipkxNfdhG9UrLwaeswfjfdF0A=
@@ -97,8 +96,8 @@ github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1/go.mod h1:7SFka0XMvUgj3hfZtyd
 github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f h1:bAs4lUbRJpnnkd9VhRV3jjAVU7DJVjMaK+IsvSeZvFo=
 github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f/go.mod h1:TdznJufoqS23FtqVCzL0ZqgP5MqXbb4fg/WgDys70nA=
 github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d/go.mod h1:+5NJ2+qvTyV9exUAL/rxXi3DcLg2Ts+ymUAY5y4NvMg=
-github.com/btcsuite/btcwallet v0.15.1 h1:SKfh/l2Bgz9sJwHZvfiVbZ8Pl3N/8fFcWWXzsAPz9GU=
-github.com/btcsuite/btcwallet v0.15.1/go.mod h1:7OFsQ8ypiRwmr67hE0z98uXgJgXGAihE79jCib9x6ag=
+github.com/btcsuite/btcwallet v0.15.2-0.20220804001213-5aafe4789850 h1:yhtY53u3I6qT0yMJg35Yfa+yCVhvoqWWKTB2D2GBNJE=
+github.com/btcsuite/btcwallet v0.15.2-0.20220804001213-5aafe4789850/go.mod h1:7OFsQ8ypiRwmr67hE0z98uXgJgXGAihE79jCib9x6ag=
 github.com/btcsuite/btcwallet/wallet/txauthor v1.2.3 h1:M2yr5UlULvpqtxUqpMxTME/pA92Z9cpqeyvAFk9lAg0=
 github.com/btcsuite/btcwallet/wallet/txauthor v1.2.3/go.mod h1:T2xSiKGpUkSLCh68aF+FMXmKK9mFqNdHl9VaqOr+JjU=
 github.com/btcsuite/btcwallet/wallet/txrules v1.2.0 h1:BtEN5Empw62/RVnZ0VcJaVtVlBijnLlJY+dwjAye2Bg=
@@ -500,8 +499,8 @@ github.com/lightninglabs/neutrino v0.14.2/go.mod h1:OICUeTCn+4Tu27YRJIpWvvqySxx4
 github.com/lightninglabs/protobuf-hex-display v1.4.3-hex-display/go.mod h1:2oKOBU042GKFHrdbgGiKax4xVrFiZu51lhacUZQ9MnE=
 github.com/lightningnetwork/lightning-onion v1.0.2-0.20220211021909-bb84a1ccb0c5 h1:TkKwqFcQTGYoI+VEqyxA8rxpCin8qDaYX0AfVRinT3k=
 github.com/lightningnetwork/lightning-onion v1.0.2-0.20220211021909-bb84a1ccb0c5/go.mod h1:7dDx73ApjEZA0kcknI799m2O5kkpfg4/gr7N092ojNo=
-github.com/lightningnetwork/lnd v0.15.0-beta.rc6.0.20220810115249-17014b592e0f h1:LSKR7f6YqDMtDgCVUruiqozjXJiVtSySDTDVesjmRqY=
-github.com/lightningnetwork/lnd v0.15.0-beta.rc6.0.20220810115249-17014b592e0f/go.mod h1:sa+hYajDLPn2I2zG99ylXOCF3yK3AQqFu0M0v97vh08=
+github.com/lightningnetwork/lnd v0.15.0-beta.rc6.0.20220825081330-cf9a9864cf25 h1:2nMMQRjS8Oi/0VbJL3Vn8aDeQC5WLDbfZYzsMxIWNcY=
+github.com/lightningnetwork/lnd v0.15.0-beta.rc6.0.20220825081330-cf9a9864cf25/go.mod h1:3C62CV5fL8F6DK8VHZJJSgNGFzXxb3OPcyCz+McrjSU=
 github.com/lightningnetwork/lnd/cert v1.1.1/go.mod h1:1P46svkkd73oSoeI4zjkVKgZNwGq8bkGuPR8z+5vQUs=
 github.com/lightningnetwork/lnd/clock v1.0.1/go.mod h1:KnQudQ6w0IAMZi1SgvecLZQZ43ra2vpDNj7H/aasemg=
 github.com/lightningnetwork/lnd/clock v1.1.0 h1:/yfVAwtPmdx45aQBoXQImeY7sOIEr7IXlImRMBOZ7GQ=
@@ -521,8 +520,8 @@ github.com/lightningnetwork/lnd/tlv v1.0.2/go.mod h1:fICAfsqk1IOsC1J7G9IdsWX1EqW
 github.com/lightningnetwork/lnd/tlv v1.0.3 h1:0xBZcPuXagP6f7TY/RnLNR4igE21ov6qUdTr5NyvhhI=
 github.com/lightningnetwork/lnd/tlv v1.0.3/go.mod h1:dzR/aZetBri+ZY/fHbwV06fNn/3UID6htQzbHfREFdo=
 github.com/lightningnetwork/lnd/tor v1.0.0/go.mod h1:RDtaAdwfAm+ONuPYwUhNIH1RAvKPv+75lHPOegUcz64=
-github.com/lightningnetwork/lnd/tor v1.0.1 h1:A11FrpU0Y//g+fA827W4VnjOeoIvExONdchlLX8wYkA=
-github.com/lightningnetwork/lnd/tor v1.0.1/go.mod h1:RDtaAdwfAm+ONuPYwUhNIH1RAvKPv+75lHPOegUcz64=
+github.com/lightningnetwork/lnd/tor v1.0.2 h1:GlumRkKdzXCX0AIvIi2UXKpeY1Q4RT7Lz/CfGpKSLrU=
+github.com/lightningnetwork/lnd/tor v1.0.2/go.mod h1:RDtaAdwfAm+ONuPYwUhNIH1RAvKPv+75lHPOegUcz64=
 github.com/ltcsuite/ltcd v0.0.0-20190101042124-f37f8bf35796 h1:sjOGyegMIhvgfq5oaue6Td+hxZuf3tDC8lAPrFldqFw=
 github.com/ltcsuite/ltcd v0.0.0-20190101042124-f37f8bf35796/go.mod h1:3p7ZTf9V1sNPI5H8P3NkTFF4LuwMdPl2DodF60qAKqY=
 github.com/ltcsuite/ltcutil v0.0.0-20181217130922-17f3b04680b6/go.mod h1:8Vg/LTOO0KYa/vlHWJ6XZAevPQThGH5sufO0Hrou/lA=
@@ -795,7 +794,6 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
-golang.org/x/exp v0.0.0-20220426173459-3bcf042a4bf5/go.mod h1:lgLbSvA5ygNOMpwM/9anMpWVlVJ7Z+cHWq/eFuinpGE=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20180702182130-06c8688daad7/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
@@ -821,7 +819,6 @@ golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.5.1/go.mod h1:5OXOZSfqPIIbmVBIIKWRFfZjPR0E5r58TLhUjH0a2Ro=
-golang.org/x/mod v0.6.0-dev.0.20211013180041-c96bc1413d57/go.mod h1:3p9vT2HGsQu2K1YbXdKPJLVgG5VJdoTa1poYQBtP1AY=
 golang.org/x/net v0.0.0-20180406214816-61147c48b25b/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180719180050-a680a1efc54d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -1027,7 +1024,6 @@ golang.org/x/tools v0.0.0-20200825202427-b303f430e36d/go.mod h1:njjCfa9FT2d7l9Bc
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.2/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.3/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
-golang.org/x/tools v0.1.8-0.20211029000441-d6a9af8af023/go.mod h1:nABZi5QlRsZVlzPpHl034qft6wpY4eDcsTt5AaioBiU=
 golang.org/x/tools v0.1.8 h1:P1HhGGuLW4aAclzjtmJdf0mJOjVUZUzOTqkAkWL+l6w=
 golang.org/x/tools v0.1.8/go.mod h1:nABZi5QlRsZVlzPpHl034qft6wpY4eDcsTt5AaioBiU=
 golang.org/x/xerrors v0.0.0-20190410155217-1f06c39b4373/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/lightning_client.go
+++ b/lightning_client.go
@@ -214,6 +214,12 @@ type LightningClient interface {
 	// received from our peers.
 	SubscribeCustomMessages(ctx context.Context) (<-chan CustomMessage,
 		<-chan error, error)
+
+	// SubscribeTransactions creates a uni-directional stream from the
+	// server to the client in which any newly discovered transactions
+	// relevant to the wallet are sent over.
+	SubscribeTransactions(ctx context.Context) (<-chan Transaction,
+		<-chan error, error)
 }
 
 // Info contains info about the connected lnd node.
@@ -1695,28 +1701,36 @@ func (s *lightningClient) ListTransactions(ctx context.Context, startHeight,
 
 	txs := make([]Transaction, len(resp.Transactions))
 	for i, respTx := range resp.Transactions {
-		rawTx, err := hex.DecodeString(respTx.RawTxHex)
+		txs[i], err = unmarshallTransaction(respTx)
 		if err != nil {
 			return nil, err
-		}
-
-		var tx wire.MsgTx
-		if err := tx.Deserialize(bytes.NewReader(rawTx)); err != nil {
-			return nil, err
-		}
-
-		txs[i] = Transaction{
-			Tx:            &tx,
-			TxHash:        tx.TxHash().String(),
-			Timestamp:     time.Unix(respTx.TimeStamp, 0),
-			Amount:        btcutil.Amount(respTx.Amount),
-			Fee:           btcutil.Amount(respTx.TotalFees),
-			Confirmations: respTx.NumConfirmations,
-			Label:         respTx.Label,
 		}
 	}
 
 	return txs, nil
+}
+
+// unmarshallTransaction turns the RPC transaction into its native counterpart.
+func unmarshallTransaction(rpcTx *lnrpc.Transaction) (Transaction, error) {
+	rawTx, err := hex.DecodeString(rpcTx.RawTxHex)
+	if err != nil {
+		return Transaction{}, err
+	}
+
+	var tx wire.MsgTx
+	if err := tx.Deserialize(bytes.NewReader(rawTx)); err != nil {
+		return Transaction{}, err
+	}
+
+	return Transaction{
+		Tx:            &tx,
+		TxHash:        tx.TxHash().String(),
+		Timestamp:     time.Unix(rpcTx.TimeStamp, 0),
+		Amount:        btcutil.Amount(rpcTx.Amount),
+		Fee:           btcutil.Amount(rpcTx.TotalFees),
+		Confirmations: rpcTx.NumConfirmations,
+		Label:         rpcTx.Label,
+	}, nil
 }
 
 // ListChannels retrieves all channels of the backing lnd node.
@@ -3896,4 +3910,64 @@ func (s *lightningClient) SubscribeCustomMessages(ctx context.Context) (
 	}()
 
 	return msgChan, errChan, nil
+}
+
+// SubscribeTransactions creates a uni-directional stream from the server to the
+// client in which any newly discovered transactions relevant to the wallet are
+// sent over.
+func (s *lightningClient) SubscribeTransactions(
+	ctx context.Context) (<-chan Transaction, <-chan error, error) {
+
+	rpcCtx := s.adminMac.WithMacaroonAuth(ctx)
+
+	// Even though SubscribeTransactions uses the same request RPC type as
+	// ListTransactions, any parameters sent on the request are ignored...
+	// There's no point exposing them here either.
+	rpcReq := &lnrpc.GetTransactionsRequest{}
+
+	client, err := s.client.SubscribeTransactions(rpcCtx, rpcReq)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var (
+		// Buffer error channel by 1 so that consumer reading from this
+		// channel does not block our exit.
+		errChan = make(chan error, 1)
+		txChan  = make(chan Transaction)
+	)
+
+	s.wg.Add(1)
+	go func() {
+		defer func() {
+			// Close channels on exit so that callers know the
+			// subscription has finished.
+			close(errChan)
+			close(txChan)
+
+			s.wg.Done()
+		}()
+
+		for {
+			rpcTx, err := client.Recv()
+			if err != nil {
+				errChan <- fmt.Errorf("receive failed: %w", err)
+				return
+			}
+
+			tx, err := unmarshallTransaction(rpcTx)
+			if err != nil {
+				errChan <- fmt.Errorf("unmarshall failed: %w",
+					err)
+			}
+
+			select {
+			case txChan <- tx:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	return txChan, errChan, nil
 }

--- a/lightning_client.go
+++ b/lightning_client.go
@@ -61,8 +61,8 @@ type LightningClient interface {
 	// limit the block range that we query over. These values can be left
 	// as zero to include all blocks. To include unconfirmed transactions
 	// in the query, endHeight must be set to -1.
-	ListTransactions(ctx context.Context, startHeight,
-		endHeight int32) ([]Transaction, error)
+	ListTransactions(ctx context.Context, startHeight, endHeight int32,
+		opts ...ListTransactionsOption) ([]Transaction, error)
 
 	// ListChannels retrieves all channels of the backing lnd node.
 	ListChannels(ctx context.Context, activeOnly, publicOnly bool) ([]ChannelInfo, error)
@@ -1681,9 +1681,22 @@ func unmarshalInvoice(resp *lnrpc.Invoice) (*Invoice, error) {
 	return invoice, nil
 }
 
+// ListTransactionsOption is a functional type for an option that modifies a
+// GetTransactionsRequest.
+type ListTransactionsOption func(r *lnrpc.GetTransactionsRequest)
+
+// WithTransactionsAccount is an option for setting the account on a
+// GetTransactionsRequest.
+func WithTransactionsAccount(account string) ListTransactionsOption {
+	return func(r *lnrpc.GetTransactionsRequest) {
+		r.Account = account
+	}
+}
+
 // ListTransactions returns all known transactions of the backing lnd node.
 func (s *lightningClient) ListTransactions(ctx context.Context, startHeight,
-	endHeight int32) ([]Transaction, error) {
+	endHeight int32, opts ...ListTransactionsOption) ([]Transaction,
+	error) {
 
 	rpcCtx, cancel := context.WithTimeout(ctx, s.timeout)
 	defer cancel()
@@ -1692,6 +1705,10 @@ func (s *lightningClient) ListTransactions(ctx context.Context, startHeight,
 	rpcIn := &lnrpc.GetTransactionsRequest{
 		StartHeight: startHeight,
 		EndHeight:   endHeight,
+	}
+
+	for _, opt := range opts {
+		opt(rpcIn)
 	}
 
 	resp, err := s.client.GetTransactions(rpcCtx, rpcIn)

--- a/lightning_client.go
+++ b/lightning_client.go
@@ -663,6 +663,18 @@ type Transaction struct {
 
 	// Label is an optional label set for on chain transactions.
 	Label string
+
+	// The hash of the block this transaction was included in.
+	BlockHash string
+
+	// The height of the block this transaction was included in.
+	BlockHeight int32
+
+	// Outputs that received funds for this transaction.
+	OutputDetails []*lnrpc.OutputDetail
+
+	// PreviousOutpoints/Inputs of this transaction.
+	PreviousOutpoints []*lnrpc.PreviousOutPoint
 }
 
 // Peer contains information about a peer we are connected to.
@@ -1740,13 +1752,17 @@ func unmarshallTransaction(rpcTx *lnrpc.Transaction) (Transaction, error) {
 	}
 
 	return Transaction{
-		Tx:            &tx,
-		TxHash:        tx.TxHash().String(),
-		Timestamp:     time.Unix(rpcTx.TimeStamp, 0),
-		Amount:        btcutil.Amount(rpcTx.Amount),
-		Fee:           btcutil.Amount(rpcTx.TotalFees),
-		Confirmations: rpcTx.NumConfirmations,
-		Label:         rpcTx.Label,
+		Tx:                &tx,
+		TxHash:            tx.TxHash().String(),
+		Timestamp:         time.Unix(rpcTx.TimeStamp, 0),
+		Amount:            btcutil.Amount(rpcTx.Amount),
+		Fee:               btcutil.Amount(rpcTx.TotalFees),
+		Confirmations:     rpcTx.NumConfirmations,
+		Label:             rpcTx.Label,
+		BlockHash:         rpcTx.BlockHash,
+		BlockHeight:       rpcTx.BlockHeight,
+		OutputDetails:     rpcTx.OutputDetails,
+		PreviousOutpoints: rpcTx.PreviousOutpoints,
 	}, nil
 }
 

--- a/lnd_services.go
+++ b/lnd_services.go
@@ -343,7 +343,7 @@ func NewLndServices(cfg *LndServicesConfig) (*GrpcLndServices, error) {
 		conn, macaroons[signerMacFilename], timeout,
 	)
 	walletKitClient := newWalletKitClient(
-		conn, macaroons[walletKitMacFilename], timeout,
+		conn, macaroons[walletKitMacFilename], timeout, chainParams,
 	)
 	invoicesClient := newInvoicesClient(
 		conn, macaroons[invoiceMacFilename], timeout,

--- a/testdata/permissions.json
+++ b/testdata/permissions.json
@@ -1032,6 +1032,14 @@
                 }
             ]
         },
+        "/walletrpc.WalletKit/ImportTaprootScript": {
+            "permissions": [
+                {
+                    "entity": "onchain",
+                    "action": "write"
+                }
+            ]
+        },
         "/walletrpc.WalletKit/LabelTransaction": {
             "permissions": [
                 {

--- a/walletkit_client.go
+++ b/walletkit_client.go
@@ -133,6 +133,10 @@ type WalletKitClient interface {
 		account string) (*psbt.Packet, *wire.MsgTx, error)
 
 	// ImportPublicKey imports a public key as watch-only into the wallet.
+	//
+	// NOTE: Events (deposits/spends) for a key will only be detected by lnd
+	// if they happen after the import. Rescans to detect past events will
+	// be supported later on.
 	ImportPublicKey(ctx context.Context, pubkey *btcec.PublicKey,
 		addrType lnwallet.AddressType) error
 }
@@ -608,6 +612,10 @@ func (m *walletKitClient) FinalizePsbt(ctx context.Context, packet *psbt.Packet,
 }
 
 // ImportPublicKey imports a public key as watch-only into the wallet.
+//
+// NOTE: Events (deposits/spends) for a key will only be detected by lnd if they
+// happen after the import. Rescans to detect past events will be supported
+// later on.
 func (m *walletKitClient) ImportPublicKey(ctx context.Context,
 	pubKey *btcec.PublicKey, addrType lnwallet.AddressType) error {
 

--- a/walletkit_client.go
+++ b/walletkit_client.go
@@ -25,12 +25,32 @@ import (
 	"google.golang.org/grpc"
 )
 
+// ListUnspentOption is a functional type for an option that modifies a
+// ListUnspentRequest.
+type ListUnspentOption func(r *walletrpc.ListUnspentRequest)
+
+// WithUnspentAccount is an option for setting the account on a
+// ListUnspentRequest.
+func WithUnspentAccount(account string) ListUnspentOption {
+	return func(r *walletrpc.ListUnspentRequest) {
+		r.Account = account
+	}
+}
+
+// WithUnspentUnconfirmedOnly is an option for setting the UnconfirmedOnly flag
+// on a ListUnspentRequest.
+func WithUnspentUnconfirmedOnly() ListUnspentOption {
+	return func(r *walletrpc.ListUnspentRequest) {
+		r.UnconfirmedOnly = true
+	}
+}
+
 // WalletKitClient exposes wallet functionality.
 type WalletKitClient interface {
 	// ListUnspent returns a list of all utxos spendable by the wallet with
 	// a number of confirmations between the specified minimum and maximum.
-	ListUnspent(ctx context.Context, minConfs, maxConfs int32) (
-		[]*lnwallet.Utxo, error)
+	ListUnspent(ctx context.Context, minConfs, maxConfs int32,
+		opts ...ListUnspentOption) ([]*lnwallet.Utxo, error)
 
 	// LeaseOutput locks an output to the given ID for the lease time
 	// provided, preventing it from being available for any future coin
@@ -182,16 +202,22 @@ func newWalletKitClient(conn grpc.ClientConnInterface,
 // ListUnspent returns a list of all utxos spendable by the wallet with a number
 // of confirmations between the specified minimum and maximum.
 func (m *walletKitClient) ListUnspent(ctx context.Context, minConfs,
-	maxConfs int32) ([]*lnwallet.Utxo, error) {
+	maxConfs int32, opts ...ListUnspentOption) ([]*lnwallet.Utxo, error) {
 
 	rpcCtx, cancel := context.WithTimeout(ctx, m.timeout)
 	defer cancel()
 
-	rpcCtx = m.walletKitMac.WithMacaroonAuth(rpcCtx)
-	resp, err := m.client.ListUnspent(rpcCtx, &walletrpc.ListUnspentRequest{
+	rpcReq := &walletrpc.ListUnspentRequest{
 		MinConfs: minConfs,
 		MaxConfs: maxConfs,
-	})
+	}
+
+	for _, opt := range opts {
+		opt(rpcReq)
+	}
+
+	rpcCtx = m.walletKitMac.WithMacaroonAuth(rpcCtx)
+	resp, err := m.client.ListUnspent(rpcCtx, rpcReq)
 	if err != nil {
 		return nil, err
 	}

--- a/walletkit_client.go
+++ b/walletkit_client.go
@@ -10,6 +10,7 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/btcutil/psbt"
+	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcwallet/wtxmgr"
@@ -140,6 +141,7 @@ type walletKitClient struct {
 	client       walletrpc.WalletKitClient
 	walletKitMac serializedMacaroon
 	timeout      time.Duration
+	params       *chaincfg.Params
 }
 
 // A compile-time constraint to ensure walletKitclient satisfies the
@@ -147,12 +149,14 @@ type walletKitClient struct {
 var _ WalletKitClient = (*walletKitClient)(nil)
 
 func newWalletKitClient(conn grpc.ClientConnInterface,
-	walletKitMac serializedMacaroon, timeout time.Duration) *walletKitClient {
+	walletKitMac serializedMacaroon, timeout time.Duration,
+	chainParams *chaincfg.Params) *walletKitClient {
 
 	return &walletKitClient{
 		client:       walletrpc.NewWalletKitClient(conn),
 		walletKitMac: walletKitMac,
 		timeout:      timeout,
+		params:       chainParams,
 	}
 }
 


### PR DESCRIPTION
~Depends on https://github.com/lightninglabs/lndclient/pull/113 and https://github.com/lightningnetwork/lnd/pull/6775.~

Adds the new `ImportTaprootScript` RPC of the `WalletKit` subserver.

#### Pull Request Checklist

- [X] PR is opened against correct version branch.
- [X] Version compatibility matrix in the README and minimal required version
      in `lnd_services.go` are updated.
- [X] Update `macaroon_recipes.go` if your PR adds a new method that is called
  differently than the RPC method it invokes.
