### PR TITLE
multi: propagate zero conf fields to the `ChannelAcceptResponse`

### DIFF
--- a/lightning_client.go
+++ b/lightning_client.go
@@ -931,6 +931,14 @@ type AcceptorRequest struct {
 	// CommitmentType is the commitment type that the initiator would like
 	// to use for the channel.
 	CommitmentType *lnwallet.CommitmentType
+
+	// WantsZeroConf indicates if initiator wants to open a zero-conf
+	// channel.
+	WantsZeroConf bool
+
+	// WantsSCIDAlias indicates if the initiator wants to use the scid-alias
+	// channel type.
+	WantsSCIDAlias bool
 }
 
 func newAcceptorRequest(req *lnrpc.ChannelAcceptRequest) (*AcceptorRequest,
@@ -985,6 +993,8 @@ func newAcceptorRequest(req *lnrpc.ChannelAcceptRequest) (*AcceptorRequest,
 		MaxAcceptedHtlcs: req.MaxAcceptedHtlcs,
 		ChannelFlags:     req.ChannelFlags,
 		CommitmentType:   commitmentType,
+		WantsZeroConf:    req.WantsZeroConf,
+		WantsSCIDAlias:   req.WantsScidAlias,
 	}, nil
 }
 
@@ -1025,6 +1035,11 @@ type AcceptorResponse struct {
 	// MinAcceptDepth is the number of confirmations we require before we
 	// consider the channel open.
 	MinAcceptDepth uint32
+
+	// ZeroConf signals that the responder wants this to be a zero-conf
+	// channel. Both nodes need to set the scid-alias feature bit.
+	// The minimum depth field must be zero if this is true.
+	ZeroConf bool
 }
 
 // QueryRoutesRequest is the request of a QueryRoutes call.
@@ -3555,6 +3570,7 @@ func (s *lightningClient) ChannelAcceptor(ctx context.Context,
 				MaxHtlcCount:    resp.MaxHtlcCount,
 				MinHtlcIn:       resp.MinHtlcIn,
 				MinAcceptDepth:  resp.MinAcceptDepth,
+				ZeroConf:        resp.ZeroConf,
 			}
 
 			if err := acceptStream.Send(rpcResp); err != nil {

--- a/lnd_services.go
+++ b/lnd_services.go
@@ -42,7 +42,7 @@ var (
 	minimalCompatibleVersion = &verrpc.Version{
 		AppMajor:  0,
 		AppMinor:  15,
-		AppPatch:  0,
+		AppPatch:  1,
 		BuildTags: DefaultBuildTags,
 	}
 


### PR DESCRIPTION
Make lndclient zeroconf ready

#### Pull Request Checklist

- [X] PR is opened against correct version branch.
- [ ] Version compatibility matrix in the README and minimal required version
      in `lnd_services.go` are updated. <= only after merging to master?
      
     
