### PR TITLE
lndclient: add WithFundingShim opt to openchannel

### DIFF
--- a/lightning_client.go
+++ b/lightning_client.go
@@ -40,6 +40,14 @@ func WithZeroConf() OpenChannelOption {
 	}
 }
 
+// WithFundingShim is an option for attaching a funding shim to an open channel
+// request.
+func WithFundingShim(shim *lnrpc.FundingShim) OpenChannelOption {
+	return func(r *lnrpc.OpenChannelRequest) {
+		r.FundingShim = shim
+	}
+}
+
 // LightningClient exposes base lightning functionality.
 type LightningClient interface {
 	PayInvoice(ctx context.Context, invoice string,


### PR DESCRIPTION
#### Pull Request Checklist

- [x] PR is opened against correct version branch.
- [x] Version compatibility matrix in the README and minimal required version
      in `lnd_services.go` are updated.
- [x] Update `macaroon_recipes.go` if your PR adds a new method that is called
  differently than the RPC method it invokes.

#### Description

Adds the ability to attach funding shims to open channel requests. It is introduced as an optional argument.