### PR TITLE
lndclient: add commitment type option to openchannel

### DIFF
--- a/lightning_client.go
+++ b/lightning_client.go
@@ -48,6 +48,14 @@ func WithFundingShim(shim *lnrpc.FundingShim) OpenChannelOption {
 	}
 }
 
+// WithCommitmentType is an option for specifying a commitment type for the open
+// channel request.
+func WithCommitmentType(t *lnrpc.CommitmentType) OpenChannelOption {
+	return func(r *lnrpc.OpenChannelRequest) {
+		r.CommitmentType = *t
+	}
+}
+
 // LightningClient exposes base lightning functionality.
 type LightningClient interface {
 	PayInvoice(ctx context.Context, invoice string,


### PR DESCRIPTION
#### Pull Request Checklist

- [x] PR is opened against correct version branch.
- [x] Version compatibility matrix in the README and minimal required version
      in `lnd_services.go` are updated.
- [x] Update `macaroon_recipes.go` if your PR adds a new method that is called
  differently than the RPC method it invokes.

#### Description

Adds another optional argument to the `OpenChannel` function which enables specifying a commitment type to be used on the channel.