### PR TITLE
lndclient: add scid opt to openchannel

### DIFF
--- a/lightning_client.go
+++ b/lightning_client.go
@@ -56,6 +56,13 @@ func WithCommitmentType(t *lnrpc.CommitmentType) OpenChannelOption {
 	}
 }
 
+// WithScid signals that the channel open should be an option-scid-alias one.
+func WithScid() OpenChannelOption {
+	return func(r *lnrpc.OpenChannelRequest) {
+		r.ScidAlias = true
+	}
+}
+
 // LightningClient exposes base lightning functionality.
 type LightningClient interface {
 	PayInvoice(ctx context.Context, invoice string,


### PR DESCRIPTION
#### Pull Request Checklist

- [x] PR is opened against correct version branch.
- [x] Version compatibility matrix in the README and minimal required version
      in `lnd_services.go` are updated.
- [x] Update `macaroon_recipes.go` if your PR adds a new method that is called
  differently than the RPC method it invokes.

#### Description

Adds an optional argument to `OpenChannel` to support scid channel opens.