### PR TITLE
lndclient: add openchannel async call

### DIFF
--- a/macaroon_recipes.go
+++ b/macaroon_recipes.go
@@ -40,6 +40,7 @@ var (
 		"ImportMissionControl":   "XImportMissionControl",
 		"EstimateFeeRate":        "EstimateFee",
 		"EstimateFeeToP2WSH":     "EstimateFee",
+		"OpenChannelStream":      "OpenChannel",
 	}
 )
 


### PR DESCRIPTION
#### Pull Request Checklist

- [x] PR is opened against correct version branch.
- [x] Version compatibility matrix in the README and minimal required version
      in `lnd_services.go` are updated.
- [x] Update `macaroon_recipes.go` if your PR adds a new method that is called
  differently than the RPC method it invokes.

#### Description

Adds a new method for asynchronous `OpenChannel`. It returns the grpc stream for the `lndclient` user to listen to updates.