### PR TITLE
hotfix/lndclient: add macaroon context to OpenChannelStream

### DIFF
--- a/lightning_client.go
+++ b/lightning_client.go
@@ -2793,6 +2793,8 @@ func (s *lightningClient) OpenChannelStream(ctx context.Context, peer route.Vert
 	opts ...OpenChannelOption) (<-chan *OpenStatusUpdate, <-chan error,
 	error) {
 
+	rpcCtx := s.adminMac.WithMacaroonAuth(ctx)
+
 	rpcRequest := &lnrpc.OpenChannelRequest{
 		NodePubkey:         peer[:],
 		LocalFundingAmount: int64(localSat),
@@ -2804,7 +2806,7 @@ func (s *lightningClient) OpenChannelStream(ctx context.Context, peer route.Vert
 		opt(rpcRequest)
 	}
 
-	updateStream, err := s.client.OpenChannel(ctx, rpcRequest)
+	updateStream, err := s.client.OpenChannel(rpcCtx, rpcRequest)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
#### Pull Request Checklist

- [x] PR is opened against correct version branch.
- [x] Version compatibility matrix in the README and minimal required version
      in `lnd_services.go` are updated.
- [x] Update `macaroon_recipes.go` if your PR adds a new method that is called
  differently than the RPC method it invokes.

#### Description

Minor hotfix PR for previous `OpenChannelStream` merge. The context used did not carry the required macaroon for the RPC call to succeed.