### PR TITLE
lightning-client: return correct context error

### DIFF
--- a/lightning_client.go
+++ b/lightning_client.go
@@ -3918,6 +3918,9 @@ func (s *lightningClient) RegisterRPCMiddleware(ctx context.Context,
 	go func() {
 		msg, err := interceptStream.Recv()
 		if err != nil {
+			log.Errorf("Could not receive from interceptor "+
+				"stream: %v", err)
+
 			errChan <- err
 			return
 		}
@@ -3927,7 +3930,7 @@ func (s *lightningClient) RegisterRPCMiddleware(ctx context.Context,
 
 	select {
 	case <-ctxc.Done():
-		return nil, ctx.Err()
+		return nil, ctxc.Err()
 
 	case err := <-errChan:
 		return nil, err


### PR DESCRIPTION
This commit fixes a bug where the in-correct context's error message is returned resulting in a nil error being returned when the context is canceled. On a middleware registration error, the first thing we will pick up here is that the context is cancelled, however, this does not provide the user with much feedback about what went wrong and so an additional log statement is also added on the stream's Recv func as this will provide the user with more info.

