### PR TITLE
chainkit: fix macaroon

### DIFF
--- a/lnd_services.go
+++ b/lnd_services.go
@@ -342,7 +342,7 @@ func NewLndServices(cfg *LndServicesConfig) (*GrpcLndServices, error) {
 		conn, macaroons[ChainNotifierServiceMac], timeout,
 	)
 	chainKitClient := newChainKitClient(
-		conn, macaroons[ChainKitServiceMac], timeout,
+		conn, macaroons[ChainNotifierServiceMac], timeout,
 	)
 	signerClient := newSignerClient(
 		conn, macaroons[SignerServiceMac], timeout,

--- a/macaroon_pouch.go
+++ b/macaroon_pouch.go
@@ -17,7 +17,6 @@ const (
 	AdminServiceMac         LnrpcServiceMac = "admin.macaroon"
 	InvoiceServiceMac       LnrpcServiceMac = "invoices.macaroon"
 	ChainNotifierServiceMac LnrpcServiceMac = "chainnotifier.macaroon"
-	ChainKitServiceMac      LnrpcServiceMac = "chainkit.macaroon"
 	WalletKitServiceMac     LnrpcServiceMac = "walletkit.macaroon"
 	RouterServiceMac        LnrpcServiceMac = "router.macaroon"
 	SignerServiceMac        LnrpcServiceMac = "signer.macaroon"
@@ -31,7 +30,6 @@ var (
 	macaroonServices = []LnrpcServiceMac{
 		InvoiceServiceMac,
 		ChainNotifierServiceMac,
-		ChainKitServiceMac,
 		SignerServiceMac,
 		WalletKitServiceMac,
 		RouterServiceMac,
@@ -112,7 +110,6 @@ func newMacaroonPouch(macaroonDir, customMacPath, customMacHex string) (macaroon
 		return macaroonPouch{
 			InvoiceServiceMac:       mac,
 			ChainNotifierServiceMac: mac,
-			ChainKitServiceMac:      mac,
 			SignerServiceMac:        mac,
 			WalletKitServiceMac:     mac,
 			RouterServiceMac:        mac,


### PR DESCRIPTION
This commit removes the unneded chainkit.macaroon dependency as the chainkit RPC service currently uses the chainnoitifer.macaroon.

#### Pull Request Checklist

- [x] PR is opened against correct version branch.
- [ ] Version compatibility matrix in the README and minimal required version
      in `lnd_services.go` are updated.
- [ ] Update `macaroon_recipes.go` if your PR adds a new method that is called
  differently than the RPC method it invokes.
