### PR TITLE
macaroons: Bolt macaroon store fix

### DIFF
--- a/macaroon_service.go
+++ b/macaroon_service.go
@@ -347,7 +347,7 @@ func (ms *MacaroonService) Interceptors() (grpc.UnaryServerInterceptor,
 // NewBoltMacaroonStore returns a new bakery.RootKeyStore, backed by a bolt DB
 // instance at the specified location.
 func NewBoltMacaroonStore(dbPath, dbFileName string,
-	dbTimeout time.Duration) (bakery.RootKeyStore, error) {
+	dbTimeout time.Duration) (bakery.RootKeyStore, kvdb.Backend, error) {
 
 	db, err := kvdb.GetBoltBackend(&kvdb.BoltBackendConfig{
 		DBPath:     dbPath,
@@ -355,15 +355,15 @@ func NewBoltMacaroonStore(dbPath, dbFileName string,
 		DBTimeout:  dbTimeout,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("unable to open macaroon "+
+		return nil, nil, fmt.Errorf("unable to open macaroon "+
 			"db: %w", err)
 	}
 
 	rks, err := macaroons.NewRootKeyStorage(db)
 	if err != nil {
-		return nil, fmt.Errorf("unable to open init macaroon "+
+		return nil, nil, fmt.Errorf("unable to open init macaroon "+
 			"db: %w", err)
 	}
 
-	return rks, nil
+	return rks, db, nil
 }

--- a/macaroon_service_test.go
+++ b/macaroon_service_test.go
@@ -24,10 +24,13 @@ func TestMacaroonServiceMigration(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll(tempDirPath)
 
-	rks, err := NewBoltMacaroonStore(
+	rks, backend, err := NewBoltMacaroonStore(
 		tempDirPath, "macaroons.db", defaultDBTimeout,
 	)
 	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, backend.Close())
+	}()
 
 	// The initial config we will use has an empty DB password.
 	cfg := &MacaroonServiceConfig{


### PR DESCRIPTION
When using the default `BoltMacaroonStore` as root key store we may want to close the BoltDB instance correctly to avoid it holding the macaroon database file until the instance is properly GCd. This commit makes this possible by returning the `kvdb` backend instance so callers can make sure to close it properly.

#### Pull Request Checklist

- [x] PR is opened against correct version branch.
- [ ] Version compatibility matrix in the README and minimal required version
      in `lnd_services.go` are updated.
- [ ] Update `macaroon_recipes.go` if your PR adds a new method that is called
  differently than the RPC method it invokes.
