### PR TITLE
lightning: fix RegisterRPCMiddleware error handling

### DIFF
--- a/lightning_client.go
+++ b/lightning_client.go
@@ -4024,8 +4024,6 @@ func (s *lightningClient) RegisterRPCMiddleware(ctx context.Context,
 		registerChan = make(chan bool, 1)
 		errChan      = make(chan error, 1)
 	)
-	ctxc, cancel := context.WithTimeout(interceptStream.Context(), timeout)
-	defer cancel()
 
 	// Read the first message in a goroutine because the Recv method blocks
 	// until the message arrives.
@@ -4043,9 +4041,6 @@ func (s *lightningClient) RegisterRPCMiddleware(ctx context.Context,
 	}()
 
 	select {
-	case <-ctxc.Done():
-		return nil, ctxc.Err()
-
 	case err := <-errChan:
 		return nil, err
 


### PR DESCRIPTION
Previously, the interceptStream's context was listened on for any context cancelation. However, this is not required since if the interceptStream's context is canceled then the `Recv()` method would also return a "context canceled" error which would be put into the `errChan` which is then listened on. If we listen on both the ctx.Done() channel and the error channel then the ctx channel will always fire first which results in a less meaningful error being returned.

