### PR TITLE
multi: hanlde empty invoice preimages for AMP invocies

### DIFF
--- a/router_client.go
+++ b/router_client.go
@@ -548,13 +548,15 @@ func unmarshallPaymentStatus(rpcPayment *lnrpc.Payment) (
 
 	switch status.State {
 	case lnrpc.Payment_SUCCEEDED:
-		preimage, err := lntypes.MakePreimageFromStr(
-			rpcPayment.PaymentPreimage,
-		)
-		if err != nil {
-			return nil, err
+		if rpcPayment.PaymentPreimage != "" {
+			preimage, err := lntypes.MakePreimageFromStr(
+				rpcPayment.PaymentPreimage,
+			)
+			if err != nil {
+				return nil, err
+			}
+			status.Preimage = preimage
 		}
-		status.Preimage = preimage
 		status.Fee = lnwire.MilliSatoshi(rpcPayment.FeeMsat)
 		status.Value = lnwire.MilliSatoshi(rpcPayment.ValueMsat)
 


### PR DESCRIPTION
An AMP invoice does not have an invoice-level preimage. Each htlc part of an AMP payment has its own hash/preimage pair.

This was blocking my litd from starting up. The account service subscribes to the invoice stream and without this changes lndclient will return an error when it is not able to parse the preimage for a settled invoice.

```
2023-05-29 19:20:24.075 [ERR] ACCT: Error in invoice subscription: invalid preimage length of 0, want 32
```

#### Pull Request Checklist

- [X] PR is opened against correct version branch.
- [X] Version compatibility matrix in the README and minimal required version
      in `lnd_services.go` are updated.
- [X] Update `macaroon_recipes.go` if your PR adds a new method that is called
  differently than the RPC method it invokes.
