### PR TITLE
mod+lightning+chainkit: update to lnd v0.17.1-beta.rc1 and expose GetBlockHeader

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,9 +7,9 @@ require (
 	github.com/btcsuite/btcd/btcutil/psbt v1.1.8
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.0.2
 	github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f
-	github.com/btcsuite/btcwallet v0.16.10-0.20230804184612-07be54bc22cf
+	github.com/btcsuite/btcwallet v0.16.10-0.20231017144732-e3ff37491e9c
 	github.com/btcsuite/btcwallet/wtxmgr v1.5.0
-	github.com/lightningnetwork/lnd v0.17.0-beta
+	github.com/lightningnetwork/lnd v0.17.1-beta.rc1
 	github.com/lightningnetwork/lnd/kvdb v1.4.4
 	github.com/stretchr/testify v1.8.2
 	google.golang.org/grpc v1.56.3
@@ -136,7 +136,6 @@ require (
 	golang.org/x/exp v0.0.0-20230315142452-642cacee5cc0 // indirect
 	golang.org/x/mod v0.10.0 // indirect
 	golang.org/x/net v0.17.0 // indirect
-	golang.org/x/sync v0.2.0 // indirect
 	golang.org/x/sys v0.13.0 // indirect
 	golang.org/x/term v0.13.0 // indirect
 	golang.org/x/text v0.13.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -83,8 +83,8 @@ github.com/btcsuite/btcd/chaincfg/chainhash v1.0.2/go.mod h1:7SFka0XMvUgj3hfZtyd
 github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f h1:bAs4lUbRJpnnkd9VhRV3jjAVU7DJVjMaK+IsvSeZvFo=
 github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f/go.mod h1:TdznJufoqS23FtqVCzL0ZqgP5MqXbb4fg/WgDys70nA=
 github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d/go.mod h1:+5NJ2+qvTyV9exUAL/rxXi3DcLg2Ts+ymUAY5y4NvMg=
-github.com/btcsuite/btcwallet v0.16.10-0.20230804184612-07be54bc22cf h1:iZrvu/dynDPUcLJFkKiN9wnS4EdjwZSJS1H33Rx/a1Y=
-github.com/btcsuite/btcwallet v0.16.10-0.20230804184612-07be54bc22cf/go.mod h1:qUPTONX2GVX7ERHvgh352/WySsfYlrkL4729qX9o9cA=
+github.com/btcsuite/btcwallet v0.16.10-0.20231017144732-e3ff37491e9c h1:+7tbYEUj0TYYIvuvE9YP+x5dU3FT/8J6Qh8d5YvQwrE=
+github.com/btcsuite/btcwallet v0.16.10-0.20231017144732-e3ff37491e9c/go.mod h1:WSKhOJWUmUOHKCKEzdt+jWAHFAE/t4RqVbCwL2pEdiU=
 github.com/btcsuite/btcwallet/wallet/txauthor v1.3.2 h1:etuLgGEojecsDOYTII8rYiGHjGyV5xTqsXi+ZQ715UU=
 github.com/btcsuite/btcwallet/wallet/txauthor v1.3.2/go.mod h1:Zpk/LOb2sKqwP2lmHjaZT9AdaKsHPSbNLm2Uql5IQ/0=
 github.com/btcsuite/btcwallet/wallet/txrules v1.2.0 h1:BtEN5Empw62/RVnZ0VcJaVtVlBijnLlJY+dwjAye2Bg=
@@ -397,8 +397,8 @@ github.com/lightninglabs/protobuf-go-hex-display v1.30.0-hex-display h1:pRdza2wl
 github.com/lightninglabs/protobuf-go-hex-display v1.30.0-hex-display/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 github.com/lightningnetwork/lightning-onion v1.2.1-0.20230823005744-06182b1d7d2f h1:Pua7+5TcFEJXIIZ1I2YAUapmbcttmLj4TTi786bIi3s=
 github.com/lightningnetwork/lightning-onion v1.2.1-0.20230823005744-06182b1d7d2f/go.mod h1:c0kvRShutpj3l6B9WtTsNTBUtjSmjZXbJd9ZBRQOSKI=
-github.com/lightningnetwork/lnd v0.17.0-beta h1:Vzl2W3ClIDdffuQD5IaZwyP7CKR/CbXxWqws72Cq51g=
-github.com/lightningnetwork/lnd v0.17.0-beta/go.mod h1:8w27nArqZ1P7U6FP9U78GlaTLNm7u9GhV5Edv1C1yRU=
+github.com/lightningnetwork/lnd v0.17.1-beta.rc1 h1:O90nWe8yYZztT4jVFO6M012N9tabwW8uOOIQnQPYrWg=
+github.com/lightningnetwork/lnd v0.17.1-beta.rc1/go.mod h1:LvdKf2VlM1gFphEqjyYnRaWdCrEhy31NNSHvONJENmU=
 github.com/lightningnetwork/lnd/clock v1.0.1/go.mod h1:KnQudQ6w0IAMZi1SgvecLZQZ43ra2vpDNj7H/aasemg=
 github.com/lightningnetwork/lnd/clock v1.1.1 h1:OfR3/zcJd2RhH0RU+zX/77c0ZiOnIMsDIBjgjWdZgA0=
 github.com/lightningnetwork/lnd/clock v1.1.1/go.mod h1:mGnAhPyjYZQJmebS7aevElXKTFDuO+uNFFfMXK1W8xQ=
@@ -717,7 +717,6 @@ golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.2.0 h1:PUR+T4wwASmuSTYdKjYHI5TD22Wy5ogLU5qZCOLxBrI=
-golang.org/x/sync v0.2.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/testdata/permissions.json
+++ b/testdata/permissions.json
@@ -40,6 +40,38 @@
                 }
             ]
         },
+        "/chainrpc.ChainKit/GetBlock": {
+            "permissions": [
+                {
+			        "entity": "onchain",
+			        "action": "read"
+                }
+            ]
+		},
+		"/chainrpc.ChainKit/GetBlockHeader": {
+            "permissions": [
+                {
+			        "entity": "onchain",
+			        "action": "read"
+                }
+            ]
+		},
+		"/chainrpc.ChainKit/GetBestBlock": {
+            "permissions": [
+                {
+			        "entity": "onchain",
+			        "action": "read"
+                }
+            ]
+		},
+		"/chainrpc.ChainKit/GetBlockHash": {
+            "permissions": [
+                {
+			        "entity": "onchain",
+			        "action": "read"
+                }
+            ]
+		},
         "/chainrpc.ChainNotifier/RegisterBlockEpochNtfn": {
             "permissions": [
                 {
@@ -520,7 +552,7 @@
                 }
             ]
         },
-	"/lnrpc.Lightning/SendCustomMessage": {
+        "/lnrpc.Lightning/SendCustomMessage": {
             "permissions": [
                 {
                     "entity": "peers",
@@ -584,7 +616,7 @@
                 }
             ]
         },
-	"/lnrpc.Lightning/SubscribeCustomMessages": {
+        "/lnrpc.Lightning/SubscribeCustomMessages": {
             "permissions": [
                 {
                     "entity": "peers",


### PR DESCRIPTION
#### Pull Request Checklist

Only bumping the lnd version to `v0.17.1-beta.rc1` and exposing the `GetBlockHeader` call.

IIUC this should go in a new branch, not master.

- [ ] PR is opened against correct version branch.
- [ ] Version compatibility matrix in the README and minimal required version
      in `lnd_services.go` are updated.
- [ ] Update `macaroon_recipes.go` if your PR adds a new method that is called
  differently than the RPC method it invokes.
