### PR TITLE
mod+lightning: update to lnd v0.17.1-beta final

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f
 	github.com/btcsuite/btcwallet v0.16.10-0.20231017144732-e3ff37491e9c
 	github.com/btcsuite/btcwallet/wtxmgr v1.5.0
-	github.com/lightningnetwork/lnd v0.17.1-beta.rc1
+	github.com/lightningnetwork/lnd v0.17.1-beta
 	github.com/lightningnetwork/lnd/kvdb v1.4.4
 	github.com/stretchr/testify v1.8.2
 	google.golang.org/grpc v1.56.3

--- a/go.sum
+++ b/go.sum
@@ -397,8 +397,8 @@ github.com/lightninglabs/protobuf-go-hex-display v1.30.0-hex-display h1:pRdza2wl
 github.com/lightninglabs/protobuf-go-hex-display v1.30.0-hex-display/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 github.com/lightningnetwork/lightning-onion v1.2.1-0.20230823005744-06182b1d7d2f h1:Pua7+5TcFEJXIIZ1I2YAUapmbcttmLj4TTi786bIi3s=
 github.com/lightningnetwork/lightning-onion v1.2.1-0.20230823005744-06182b1d7d2f/go.mod h1:c0kvRShutpj3l6B9WtTsNTBUtjSmjZXbJd9ZBRQOSKI=
-github.com/lightningnetwork/lnd v0.17.1-beta.rc1 h1:O90nWe8yYZztT4jVFO6M012N9tabwW8uOOIQnQPYrWg=
-github.com/lightningnetwork/lnd v0.17.1-beta.rc1/go.mod h1:LvdKf2VlM1gFphEqjyYnRaWdCrEhy31NNSHvONJENmU=
+github.com/lightningnetwork/lnd v0.17.1-beta h1:ya5pXahwrEJ9Sj9TQu0rIsOr1dMK8myuFMslZlmVmhA=
+github.com/lightningnetwork/lnd v0.17.1-beta/go.mod h1:wgnCM0tlwxUDZ9y7CeBkXtBJkaY45+R8A3XAgsFS0MA=
 github.com/lightningnetwork/lnd/clock v1.0.1/go.mod h1:KnQudQ6w0IAMZi1SgvecLZQZ43ra2vpDNj7H/aasemg=
 github.com/lightningnetwork/lnd/clock v1.1.1 h1:OfR3/zcJd2RhH0RU+zX/77c0ZiOnIMsDIBjgjWdZgA0=
 github.com/lightningnetwork/lnd/clock v1.1.1/go.mod h1:mGnAhPyjYZQJmebS7aevElXKTFDuO+uNFFfMXK1W8xQ=


### PR DESCRIPTION
Bumping the lnd version now that 0.17.1 is out of RC.

#### Pull Request Checklist

- [x] PR is opened against correct version branch.
- [x] Version compatibility matrix in the README and minimal required version
      in `lnd_services.go` are updated.
- [x] Update `macaroon_recipes.go` if your PR adds a new method that is called
  differently than the RPC method it invokes.
