### PR TITLE
lnd_services: increase client gRPC max receive size

### DIFF
--- a/lnd_services.go
+++ b/lnd_services.go
@@ -789,8 +789,8 @@ var (
 	defaultChainSubDir = "chain"
 
 	// maxMsgRecvSize is the largest gRPC message our client will receive.
-	// We set this to 200MiB.
-	maxMsgRecvSize = grpc.MaxCallRecvMsgSize(1 * 1024 * 1024 * 200)
+	// We set this to 400MiB.
+	maxMsgRecvSize = grpc.MaxCallRecvMsgSize(400 * 1024 * 1024)
 )
 
 func getClientConn(cfg *LndServicesConfig) (*grpc.ClientConn, error) {


### PR DESCRIPTION
This is a temporary workaround for https://github.com/lightninglabs/faraday/issues/177.
We should start paginating certain calls to `lnd` in our projects, seems like the `GetTransactions` call would be the most urgent candidate.

#### Pull Request Checklist

- [x] PR is opened against correct version branch.
- [ ] Version compatibility matrix in the README and minimal required version
      in `lnd_services.go` are updated.
- [ ] Update `macaroon_recipes.go` if your PR adds a new method that is called
  differently than the RPC method it invokes.
