### PR TITLE
invoices_client: account for invoice hash being nil.

### DIFF
--- a/invoices_client.go
+++ b/invoices_client.go
@@ -148,9 +148,16 @@ func (s *invoicesClient) AddHoldInvoice(ctx context.Context,
 	rpcCtx, cancel := context.WithTimeout(ctx, s.timeout)
 	defer cancel()
 
+	var hashBytes []byte
+	if in.Hash != nil {
+		hashBytes = in.Hash[:]
+	} else {
+		hashBytes = nil
+	}
+
 	rpcIn := &invoicesrpc.AddHoldInvoiceRequest{
 		Memo:       in.Memo,
-		Hash:       in.Hash[:],
+		Hash:       hashBytes,
 		Value:      int64(in.Value.ToSatoshis()),
 		Expiry:     in.Expiry,
 		CltvExpiry: in.CltvExpiry,


### PR DESCRIPTION
When the invoice hash is nil, a random one should be generated for us. Hence, the `AddHoldInvoice` function must account for a nil value.
