### PR TITLE
lndclient: add rpc/daemon state client to services

### DIFF
--- a/lnd_services.go
+++ b/lnd_services.go
@@ -381,6 +381,7 @@ func NewLndServices(cfg *LndServicesConfig) (*GrpcLndServices, error) {
 			Invoices:      invoicesClient,
 			Router:        routerClient,
 			Versioner:     versionerClient,
+			State:         stateClient,
 			ChainParams:   chainParams,
 			NodeAlias:     nodeAlias,
 			NodePubkey:    route.Vertex(nodeKey),


### PR DESCRIPTION
## Objective

Add the `state` RPC client to the list of exported LND services. This may be useful in assessing health of `lnd` instances from the payment service's health checking routines.

#### Pull Request Checklist

- [ ] PR is opened against correct version branch.
- [ ] Version compatibility matrix in the README and minimal required version
      in `lnd_services.go` are updated.
- [ ] Update `macaroon_recipes.go` if your PR adds a new method that is called
  differently than the RPC method it invokes.
