### PR TITLE
Add openchannel reserve option

### DIFF
--- a/lightning_client.go
+++ b/lightning_client.go
@@ -64,6 +64,15 @@ func WithScid() OpenChannelOption {
 	}
 }
 
+// WithRemoteReserve signals that the channel open should set a remote reserve
+// amount.
+func WithRemoteReserve(reserve uint64) OpenChannelOption {
+	return func(r *lnrpc.OpenChannelRequest) {
+		r.RemoteChanReserveSat = reserve
+	}
+
+}
+
 // LightningClient exposes base lightning functionality.
 type LightningClient interface {
 	PayInvoice(ctx context.Context, invoice string,


### PR DESCRIPTION
## Description

This PR adds an optional argument to the open channel request for the remote reserve amount.
