### PR TITLE
Add `RawClientWithMacAuth` to each client

### DIFF
--- a/lightning_client.go
+++ b/lightning_client.go
@@ -70,11 +70,12 @@ func WithRemoteReserve(reserve uint64) OpenChannelOption {
 	return func(r *lnrpc.OpenChannelRequest) {
 		r.RemoteChanReserveSat = reserve
 	}
-
 }
 
 // LightningClient exposes base lightning functionality.
 type LightningClient interface {
+	ServiceClient[lnrpc.LightningClient]
+
 	PayInvoice(ctx context.Context, invoice string,
 		maxFee btcutil.Amount,
 		outgoingChannel *uint64) chan PaymentResult
@@ -1321,6 +1322,10 @@ type lightningClient struct {
 	adminMac serializedMacaroon
 }
 
+// A compile time check to ensure that lightningClient implements the
+// LightningClient interface.
+var _ LightningClient = (*lightningClient)(nil)
+
 func newLightningClient(conn grpc.ClientConnInterface, timeout time.Duration,
 	params *chaincfg.Params, adminMac serializedMacaroon) *lightningClient {
 
@@ -1342,6 +1347,15 @@ type PaymentResult struct {
 
 func (s *lightningClient) WaitForFinished() {
 	s.wg.Wait()
+}
+
+// RawClientWithMacAuth returns a context with the proper macaroon
+// authentication, the default RPC timeout, and the raw client.
+func (s *lightningClient) RawClientWithMacAuth(
+	parentCtx context.Context) (context.Context, time.Duration,
+	lnrpc.LightningClient) {
+
+	return s.adminMac.WithMacaroonAuth(parentCtx), s.timeout, s.client
 }
 
 // WalletBalance returns a summary of the node's wallet balance.

--- a/lnd_services.go
+++ b/lnd_services.go
@@ -78,6 +78,14 @@ var (
 	}
 )
 
+// ServiceClient is an interface that all lnd service clients need to implement.
+type ServiceClient[T any] interface {
+	// RawClientWithMacAuth returns a context with the proper macaroon
+	// authentication, the default RPC timeout, and the raw client.
+	RawClientWithMacAuth(parentCtx context.Context) (context.Context,
+		time.Duration, T)
+}
+
 // LndServicesConfig holds all configuration settings that are needed to connect
 // to an lnd node.
 type LndServicesConfig struct {

--- a/lnd_services.go
+++ b/lnd_services.go
@@ -307,7 +307,7 @@ func NewLndServices(cfg *LndServicesConfig) (*GrpcLndServices, error) {
 	}
 
 	basicClient := lnrpc.NewLightningClient(conn)
-	stateClient := newStateClient(conn, readonlyMac)
+	stateClient := newStateClient(conn, readonlyMac, timeout)
 	versionerClient := newVersionerClient(conn, readonlyMac, timeout)
 
 	cleanupConn := func() {

--- a/lnd_services_test.go
+++ b/lnd_services_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/verrpc"
@@ -16,6 +17,15 @@ import (
 type mockVersioner struct {
 	version *verrpc.Version
 	err     error
+}
+
+// RawClientWithMacAuth returns a context with the proper macaroon
+// authentication, the default RPC timeout, and the raw client.
+func (m *mockVersioner) RawClientWithMacAuth(
+	parentCtx context.Context) (context.Context, time.Duration,
+	verrpc.VersionerClient) {
+
+	return parentCtx, 0, nil
 }
 
 func (m *mockVersioner) GetVersion(_ context.Context) (*verrpc.Version, error) {

--- a/macaroon_recipes.go
+++ b/macaroon_recipes.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"slices"
 	"strings"
 )
 
@@ -43,6 +44,12 @@ var (
 		"OpenChannelStream":      "OpenChannel",
 		"ListSweepsVerbose":      "ListSweeps",
 	}
+
+	// ignores is a list of method names on the client implementations that
+	// we don't need to check macaroon permissions for.
+	ignores = []string{
+		"RawClientWithMacAuth",
+	}
 )
 
 // MacaroonRecipe returns a list of macaroon permissions that is required to use
@@ -77,6 +84,10 @@ func MacaroonRecipe(c LightningClient, packages []string) ([]MacaroonPermission,
 			rename, ok := renames[methodName]
 			if ok {
 				methodName = rename
+			}
+
+			if slices.Contains(ignores, methodName) {
+				continue
 			}
 
 			// The full RPC URI is /package.Service/MethodName.

--- a/router_client.go
+++ b/router_client.go
@@ -31,6 +31,8 @@ var ErrRouterShuttingDown = errors.New("router shutting down")
 
 // RouterClient exposes payment functionality.
 type RouterClient interface {
+	ServiceClient[routerrpc.RouterClient]
+
 	// SendPayment attempts to route a payment to the final destination. The
 	// call returns a payment update stream and an error stream.
 	SendPayment(ctx context.Context, request SendPaymentRequest) (
@@ -401,6 +403,10 @@ type routerClient struct {
 	wg           sync.WaitGroup
 }
 
+// A compile time check to ensure that routerClient implements the RouterClient
+// interface.
+var _ RouterClient = (*routerClient)(nil)
+
 func newRouterClient(conn grpc.ClientConnInterface,
 	routerKitMac serializedMacaroon, timeout time.Duration) *routerClient {
 
@@ -420,6 +426,15 @@ func (r *routerClient) WaitForFinished() {
 	})
 
 	r.wg.Wait()
+}
+
+// RawClientWithMacAuth returns a context with the proper macaroon
+// authentication, the default RPC timeout, and the raw client.
+func (r *routerClient) RawClientWithMacAuth(
+	parentCtx context.Context) (context.Context, time.Duration,
+	routerrpc.RouterClient) {
+
+	return r.routerKitMac.WithMacaroonAuth(parentCtx), r.timeout, r.client
 }
 
 // SendPayment attempts to route a payment to the final destination. The call

--- a/state_client.go
+++ b/state_client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"google.golang.org/grpc"
@@ -90,17 +91,19 @@ func (s WalletState) ReadyForGetInfo() bool {
 type stateClient struct {
 	client      lnrpc.StateClient
 	readonlyMac serializedMacaroon
+	timeout     time.Duration
 
 	wg sync.WaitGroup
 }
 
 // newStateClient returns a new stateClient.
 func newStateClient(conn grpc.ClientConnInterface,
-	readonlyMac serializedMacaroon) *stateClient {
+	readonlyMac serializedMacaroon, timeout time.Duration) *stateClient {
 
 	return &stateClient{
 		client:      lnrpc.NewStateClient(conn),
 		readonlyMac: readonlyMac,
+		timeout:     timeout,
 	}
 }
 

--- a/state_client.go
+++ b/state_client.go
@@ -12,6 +12,8 @@ import (
 
 // StateClient exposes base lightning functionality.
 type StateClient interface {
+	ServiceClient[lnrpc.StateClient]
+
 	// SubscribeState subscribes to the current state of the wallet.
 	SubscribeState(ctx context.Context) (chan WalletState, chan error,
 		error)
@@ -96,6 +98,10 @@ type stateClient struct {
 	wg sync.WaitGroup
 }
 
+// A compile time check to ensure that stateClient implements the StateClient
+// interface.
+var _ StateClient = (*stateClient)(nil)
+
 // newStateClient returns a new stateClient.
 func newStateClient(conn grpc.ClientConnInterface,
 	readonlyMac serializedMacaroon, timeout time.Duration) *stateClient {
@@ -110,6 +116,15 @@ func newStateClient(conn grpc.ClientConnInterface,
 // WaitForFinished waits until all state subscriptions have finished.
 func (s *stateClient) WaitForFinished() {
 	s.wg.Wait()
+}
+
+// RawClientWithMacAuth returns a context with the proper macaroon
+// authentication, the default RPC timeout, and the raw client.
+func (s *stateClient) RawClientWithMacAuth(
+	parentCtx context.Context) (context.Context, time.Duration,
+	lnrpc.StateClient) {
+
+	return s.readonlyMac.WithMacaroonAuth(parentCtx), s.timeout, s.client
 }
 
 // SubscribeState subscribes to the current state of the wallet.


### PR DESCRIPTION
This allows us to use the underlying RPC methods directly while still taking advantage of the macaroon management.

Using the raw RPC methods directly can be useful when a new method isn't implemented in `lndclient` yet or when we want to pass the raw RPC request method directly instead of converting it to the `lndclient` structs.

#### Pull Request Checklist

- [X] PR is opened against correct version branch.
- [X] Version compatibility matrix in the README and minimal required version
      in `lnd_services.go` are updated.
- [X] Update `macaroon_recipes.go` if your PR adds a new method that is called
  differently than the RPC method it invokes.
