### PR TITLE
invoiecs: fix value conversion bug in AddHodlInvoice

### DIFF
--- a/invoices_client.go
+++ b/invoices_client.go
@@ -227,7 +227,7 @@ func (s *invoicesClient) AddHoldInvoice(ctx context.Context,
 	rpcIn := &invoicesrpc.AddHoldInvoiceRequest{
 		Memo:       in.Memo,
 		Hash:       in.Hash[:],
-		Value:      int64(in.Value.ToSatoshis()),
+		ValueMsat:  int64(in.Value),
 		Expiry:     in.Expiry,
 		CltvExpiry: in.CltvExpiry,
 		Private:    true,


### PR DESCRIPTION
Before this commit, callers wouldn't be able to use an msat amount as input to the hold invoice RPC call. Instead, the wrapper logic would always convert to msat first, causing a loss in precision. For most cases, sat amounts are fine, but some use cases require higher precision.

We fix this by keeping the input value in mSat (as typed), while using the `ValueMsat` field as `lnd` would expect.

#### Pull Request Checklist

- [ ] PR is opened against correct version branch.
- [ ] Version compatibility matrix in the README and minimal required version
      in `lnd_services.go` are updated.
- [ ] Update `macaroon_recipes.go` if your PR adds a new method that is called
  differently than the RPC method it invokes.
