### PR TITLE
lndclient: update lndclient grpc max recv size

### DIFF
--- a/lnd_services.go
+++ b/lnd_services.go
@@ -790,8 +790,8 @@ var (
 	defaultChainSubDir = "chain"
 
 	// maxMsgRecvSize is the largest gRPC message our client will receive.
-	// We set this to 600MiB.
-	maxMsgRecvSize = grpc.MaxCallRecvMsgSize(600 * 1024 * 1024)
+	// We set this to 800MiB.
+	maxMsgRecvSize = grpc.MaxCallRecvMsgSize(800 * 1024 * 1024)
 )
 
 func getClientConn(cfg *LndServicesConfig) (*grpc.ClientConn, error) {


### PR DESCRIPTION
### References:
- Related to this PR:  https://github.com/lightninglabs/faraday/pull/201

### Error:
```
Exception: Unexpected response from Faraday API: {'code': 8, 'message': 'grpc: received message larger than max (630803848 vs. 629145600)', 'details': []}
```

The gRPC message size limit is being increased to 800 MiB to accommodate large payloads generated by specific use cases, such as transaction histories or detailed audit reports. Trying to strike a balance between supporting current operational needs and maintaining resource efficiency.