### PR TITLE
bumpfee: add more flags as options 

### DIFF
--- a/lnd_services.go
+++ b/lnd_services.go
@@ -372,6 +372,7 @@ func NewLndServices(cfg *LndServicesConfig) (*GrpcLndServices, error) {
 	)
 	walletKitClient := newWalletKitClient(
 		conn, macaroons[WalletKitServiceMac], timeout, chainParams,
+		version,
 	)
 	invoicesClient := newInvoicesClient(
 		conn, macaroons[InvoiceServiceMac], timeout,

--- a/walletkit_client.go
+++ b/walletkit_client.go
@@ -20,6 +20,7 @@ import (
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/signrpc"
+	"github.com/lightningnetwork/lnd/lnrpc/verrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/walletrpc"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
@@ -219,6 +220,7 @@ type walletKitClient struct {
 	walletKitMac serializedMacaroon
 	timeout      time.Duration
 	params       *chaincfg.Params
+	version      *verrpc.Version
 }
 
 // A compile time check to ensure that  walletKitClient implements the
@@ -227,13 +229,15 @@ var _ WalletKitClient = (*walletKitClient)(nil)
 
 func newWalletKitClient(conn grpc.ClientConnInterface,
 	walletKitMac serializedMacaroon, timeout time.Duration,
-	chainParams *chaincfg.Params) *walletKitClient {
+	chainParams *chaincfg.Params,
+	version *verrpc.Version) *walletKitClient {
 
 	return &walletKitClient{
 		client:       walletrpc.NewWalletKitClient(conn),
 		walletKitMac: walletKitMac,
 		timeout:      timeout,
 		params:       chainParams,
+		version:      version,
 	}
 }
 
@@ -771,6 +775,15 @@ func WithBudget(budget btcutil.Amount) BumpFeeOption {
 	}
 }
 
+// targetConfFixed is the minimum version in which bug #9470 is merged and new
+// meaning of TargetConf is enabled. In versions prior to this version the field
+// had a different meaning.
+var targetConfFixed = &verrpc.Version{
+	AppMajor: 0,
+	AppMinor: 18,
+	AppPatch: 5,
+}
+
 // BumpFee attempts to bump the fee of a transaction by spending one of its
 // outputs at the given fee rate. This essentially results in a
 // child-pays-for-parent (CPFP) scenario. If the given output has been used in a
@@ -798,6 +811,19 @@ func (m *walletKitClient) BumpFee(ctx context.Context, op wire.OutPoint,
 	// Make sure that feeRate and WithTargetConf are not used together.
 	if feeRate != 0 && req.TargetConf != 0 {
 		return fmt.Errorf("can't use target_conf if feeRate != 0")
+	}
+
+	// Make sure that the version of LND is at least targetConfFixed,
+	// because before it the meaning of TargetConf was different. See
+	// https://github.com/lightningnetwork/lnd/pull/9470
+	// TODO(Boris): remove this check when minimalCompatibleVersion
+	// is bumped to targetConfFixed.
+	if req.TargetConf != 0 {
+		err := AssertVersionCompatible(m.version, targetConfFixed)
+		if err != nil {
+			return fmt.Errorf("can't use target_conf before " +
+				"version 0.18.5, see #9470")
+		}
 	}
 
 	_, err := m.client.BumpFee(m.walletKitMac.WithMacaroonAuth(rpcCtx), req)

--- a/walletkit_client.go
+++ b/walletkit_client.go
@@ -755,8 +755,8 @@ func (m *walletKitClient) BumpFee(ctx context.Context, op wire.OutPoint,
 				TxidBytes:   op.Hash[:],
 				OutputIndex: op.Index,
 			},
-			SatPerByte: uint32(feeRate.FeePerKVByte() / 1000),
-			Force:      false,
+			SatPerVbyte: uint64(feeRate.FeePerKVByte() / 1000),
+			Immediate:   false,
 		},
 	)
 	return err


### PR DESCRIPTION
Use new fields instead of deprecated

'force' -> 'immediate'
'sat_per_byte' -> 'sat_per_vbyte'

New options added: 'immediate', 'target_conf', 'budget'.

#### Pull Request Checklist

- [ ] PR is opened against correct version branch.
- [ ] Version compatibility matrix in the README and minimal required version
      in `lnd_services.go` are updated.
- [ ] Update `macaroon_recipes.go` if your PR adds a new method that is called
  differently than the RPC method it invokes.
