### PR TITLE
AddInvoice: expose field Private

### DIFF
--- a/lightning_client.go
+++ b/lightning_client.go
@@ -1580,7 +1580,7 @@ func (s *lightningClient) AddInvoice(ctx context.Context,
 		DescriptionHash: in.DescriptionHash,
 		Expiry:          in.Expiry,
 		CltvExpiry:      in.CltvExpiry,
-		Private:         true,
+		Private:         in.Private,
 	}
 
 	if in.Preimage != nil {

--- a/lightning_client_test.go
+++ b/lightning_client_test.go
@@ -66,7 +66,6 @@ func TestLightningClientAddInvoice(t *testing.T) {
 		DescriptionHash: validAddInvoiceData.DescriptionHash,
 		Expiry:          validAddInvoiceData.Expiry,
 		CltvExpiry:      validAddInvoiceData.CltvExpiry,
-		Private:         true,
 	}
 
 	validPayReq := "a valid pay req"
@@ -83,6 +82,22 @@ func TestLightningClientAddInvoice(t *testing.T) {
 		*lnrpc.AddInvoiceResponse, error) {
 
 		return validResp, nil
+	}
+
+	privateAddInvoiceData := *validAddInvoiceData
+	privateAddInvoiceData.Private = true
+	privateInvoice := &lnrpc.Invoice{
+		Memo:            validAddInvoiceData.Memo,
+		RPreimage:       validAddInvoiceData.Preimage[:],
+		RHash:           validAddInvoiceData.Hash[:],
+		ValueMsat:       int64(validAddInvoiceData.Value),
+		DescriptionHash: validAddInvoiceData.DescriptionHash,
+		Expiry:          validAddInvoiceData.Expiry,
+		CltvExpiry:      validAddInvoiceData.CltvExpiry,
+		Private:         true,
+	}
+	privateAddInvoiceArgs := []addInvoiceArg{
+		{in: privateInvoice},
 	}
 
 	errorAddInvoice := func(in *lnrpc.Invoice, opts ...grpc.CallOption) (
@@ -119,7 +134,20 @@ func TestLightningClientAddInvoice(t *testing.T) {
 				hash:           validRHash,
 				payRequest:     validPayReq,
 			},
-		}, {
+		},
+		{
+			name: "private invoice",
+			client: mockRPCClient{
+				addInvoice: validAddInvoice,
+			},
+			invoice: &privateAddInvoiceData,
+			expect: expect{
+				addInvoiceArgs: privateAddInvoiceArgs,
+				hash:           validRHash,
+				payRequest:     validPayReq,
+			},
+		},
+		{
 			name: "rpc client error",
 			client: mockRPCClient{
 				addInvoice: errorAddInvoice,


### PR DESCRIPTION
#### Description

Previously we'd always pass Private=true.

Fix https://github.com/lightninglabs/lndclient/issues/207

#### Pull Request Checklist

- [ ] PR is opened against correct version branch.
- [ ] Version compatibility matrix in the README and minimal required version
      in `lnd_services.go` are updated.
- [ ] Update `macaroon_recipes.go` if your PR adds a new method that is called
  differently than the RPC method it invokes.
