### PR TITLE
signer: option to add the local nonce to the MuSig2 session

### DIFF
--- a/signer_client.go
+++ b/signer_client.go
@@ -579,6 +579,13 @@ func MuSig2TaprootTweakOpt(scriptRoot []byte,
 	}
 }
 
+// MuSig2LocalNonceOpt adds the local secret nonce to the musig session request.
+func MuSig2LocalNonceOpt(nonce [musig2.SecNonceSize]byte) MuSig2SessionOpts {
+	return func(s *signrpc.MuSig2SessionRequest) {
+		s.PregeneratedLocalNonce = nonce[:]
+	}
+}
+
 // marshallMuSig2Version translates the passed input.MuSig2Version value to
 // signrpc.MuSig2Version.
 func marshallMuSig2Version(version input.MuSig2Version) (


### PR DESCRIPTION
#### Pull Request Checklist

- [x] PR is opened against correct version branch.
- [ ] Version compatibility matrix in the README and minimal required version
      in `lnd_services.go` are updated.
- [ ] Update `macaroon_recipes.go` if your PR adds a new method that is called
  differently than the RPC method it invokes.
