### PR TITLE
signer_client: correctly use 32-byte key for schnorr

### DIFF
--- a/signer_client.go
+++ b/signer_client.go
@@ -502,6 +502,12 @@ func (s *signerClient) VerifyMessage(ctx context.Context, msg, sig []byte,
 		opt(rpcIn)
 	}
 
+	// If the signature is a Schnorr signature, we need to set the public
+	// key as the 32-byte x-only key, as mentioned in the RPC docs.
+	if rpcIn.IsSchnorrSig {
+		rpcIn.Pubkey = pubkey[1:]
+	}
+
 	rpcCtx = s.signerMac.WithMacaroonAuth(rpcCtx)
 	resp, err := s.client.VerifyMessage(rpcCtx, rpcIn)
 	if err != nil {


### PR DESCRIPTION
This was incorrect all along, seems like we haven't actually used the `VerifySchnorr()` option in any project yet.

This is needed for https://github.com/lightninglabs/taproot-assets/pull/1502.

#### Pull Request Checklist

- [ ] PR is opened against correct version branch.
- [ ] Version compatibility matrix in the README and minimal required version
      in `lnd_services.go` are updated.
- [ ] Update `macaroon_recipes.go` if your PR adds a new method that is called
  differently than the RPC method it invokes.
