### PR TITLE
signer: allow passing nil keyLocator to DeriveSharedKey

### DIFF
--- a/signer_client.go
+++ b/signer_client.go
@@ -533,10 +533,13 @@ func (s *signerClient) DeriveSharedKey(ctx context.Context,
 
 	rpcIn := &signrpc.SharedKeyRequest{
 		EphemeralPubkey: ephemeralPubKey.SerializeCompressed(),
-		KeyLoc: &signrpc.KeyLocator{
+	}
+
+	if keyLocator != nil {
+		rpcIn.KeyLoc = &signrpc.KeyLocator{
 			KeyFamily: int32(keyLocator.Family),
 			KeyIndex:  int32(keyLocator.Index),
-		},
+		}
 	}
 
 	rpcCtx = s.signerMac.WithMacaroonAuth(rpcCtx)


### PR DESCRIPTION
Previously if the `keyLocaltor` argument was unset `DeriveSharedKey` would crash.

#### Pull Request Checklist

- [x] PR is opened against correct version branch.
- [ ] Version compatibility matrix in the README and minimal required version
      in `lnd_services.go` are updated.
- [ ] Update `macaroon_recipes.go` if your PR adds a new method that is called
  differently than the RPC method it invokes.
