### PR TITLE
walletkit: add RPC GetTransaction

### DIFF
--- a/testdata/permissions.json
+++ b/testdata/permissions.json
@@ -1136,6 +1136,14 @@
                 }
             ]
         },
+        "/walletrpc.WalletKit/GetTransaction": {
+            "permissions": [
+                {
+                    "entity": "onchain",
+                    "action": "read"
+                }
+            ]
+        },
         "/walletrpc.WalletKit/PendingSweeps": {
             "permissions": [
                 {


### PR DESCRIPTION
https://lightning.engineering/api-docs/api/lnd/wallet-kit/get-transaction/

The RPC is available since LND 0.18.0.

#### Pull Request Checklist

- [ ] PR is opened against correct version branch.
- [ ] Version compatibility matrix in the README and minimal required version
      in `lnd_services.go` are updated.
- [ ] Update `macaroon_recipes.go` if your PR adds a new method that is called
  differently than the RPC method it invokes.
