### PR TITLE
linter: enforce some constraints from code guidelines

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,6 +26,14 @@ linters-settings:
       - G115 # Integer overflow conversion.
   staticcheck:
     checks: ["-SA1019"]
+  revive:
+    rules:
+      - name: exported # To enforce conventions around exported comments.
+
+issues:
+  include:
+    - EXC0012 # revive: Exported vars should have a docstring.
+    - EXC0014 # revive: Exported vars's docstring should start with its name.
 
 linters:
   enable-all: true
@@ -92,7 +100,6 @@ linters:
   - importas
   - interfacebloat
   - protogetter
-  - revive
   - depguard
   - mnd
   - perfsprint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,6 +4,8 @@ run:
   go: "1.23"
 
 linters-settings:
+  lll:
+    line-length: 80
   govet:
     # Don't report about shadowed variables
     shadow: false
@@ -30,10 +32,6 @@ linters:
   disable:
   # Global variables are used in many places throughout the code base.
   - gochecknoglobals
-
-  # Some lines are over 80 characters on purpose and we don't want to make them
-  # even longer by marking them as 'nolint'.
-  - lll
 
   # We want to allow short variable names.
   - varnamelen

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,12 @@ ifneq ($(workers),)
 LINT_WORKERS = --concurrency=$(workers)
 endif
 
-DOCKER_TOOLS = docker run -v $$(pwd):/build lndclient-tools
+DOCKER_TOOLS = docker run \
+  --rm \
+  -v $(shell bash -c "$(GOCC) env GOCACHE || (mkdir -p /tmp/go-cache; echo /tmp/go-cache)"):/tmp/build/.cache \
+  -v $(shell bash -c "$(GOCC) env GOMODCACHE || (mkdir -p /tmp/go-modcache; echo /tmp/go-modcache)"):/tmp/build/.modcache \
+  -v $(shell bash -c "mkdir -p /tmp/go-lint-cache; echo /tmp/go-lint-cache"):/root/.cache/golangci-lint \
+  -v $$(pwd):/build lndclient-tools
 
 GREEN := "\\033[0;32m"
 NC := "\\033[0m"

--- a/chainkit_client.go
+++ b/chainkit_client.go
@@ -126,8 +126,8 @@ func (s *chainKitClient) GetBlockHeader(ctxParent context.Context,
 
 // GetBestBlock returns the block hash and current height from the valid
 // most-work chain.
-func (s *chainKitClient) GetBestBlock(ctxParent context.Context) (chainhash.Hash,
-	int32, error) {
+func (s *chainKitClient) GetBestBlock(
+	ctxParent context.Context) (chainhash.Hash, int32, error) {
 
 	ctx, cancel := context.WithTimeout(ctxParent, s.timeout)
 	defer cancel()

--- a/chainnotifier_client.go
+++ b/chainnotifier_client.go
@@ -29,7 +29,7 @@ type NotifierOptions struct {
 	ReOrgChan chan struct{}
 }
 
-// defaultNotifierOptions returns the set of default options for the notifier.
+// DefaultNotifierOptions returns the set of default options for the notifier.
 func DefaultNotifierOptions() *NotifierOptions {
 	return &NotifierOptions{}
 }

--- a/lightning_client.go
+++ b/lightning_client.go
@@ -769,15 +769,21 @@ type ForceCloseAnchorState int32
 const (
 	// ForceCloseAnchorStateLimbo is set if the recovered_balance is zero
 	// and limbo_balance is non-zero.
-	ForceCloseAnchorStateLimbo = ForceCloseAnchorState(lnrpc.PendingChannelsResponse_ForceClosedChannel_LIMBO)
+	ForceCloseAnchorStateLimbo = ForceCloseAnchorState(
+		lnrpc.PendingChannelsResponse_ForceClosedChannel_LIMBO,
+	)
 
 	// ForceCloseAnchorStateRecovered is set if the recovered_balance is
 	// non-zero.
-	ForceCloseAnchorStateRecovered = ForceCloseAnchorState(lnrpc.PendingChannelsResponse_ForceClosedChannel_RECOVERED)
+	ForceCloseAnchorStateRecovered = ForceCloseAnchorState(
+		lnrpc.PendingChannelsResponse_ForceClosedChannel_RECOVERED,
+	)
 
 	// ForceCloseAnchorStateLost indicates a state that is neither
 	// ForceCloseAnchorStateLimbo nor ForceCloseAnchorStateRecovered.
-	ForceCloseAnchorStateLost = ForceCloseAnchorState(lnrpc.PendingChannelsResponse_ForceClosedChannel_LOST)
+	ForceCloseAnchorStateLost = ForceCloseAnchorState(
+		lnrpc.PendingChannelsResponse_ForceClosedChannel_LOST,
+	)
 )
 
 // String provides the string representation of a close initiator.
@@ -2157,7 +2163,8 @@ type WaitingCloseChannel struct {
 	RemotePending chainhash.Hash
 
 	// ChanStatusFlags specifies the current channel state, examples:
-	//   - ChanStatusBorked|ChanStatusCommitBroadcasted|ChanStatusLocalCloseInitiator
+	//   - ChanStatusBorked|ChanStatusCommitBroadcasted|
+	//     ChanStatusLocalCloseInitiator
 	//   - ChanStatusCoopBroadcasted|ChanStatusLocalCloseInitiator
 	//   - ChanStatusCoopBroadcasted|ChanStatusRemoteCloseInitiator
 	ChanStatusFlags string
@@ -2167,8 +2174,8 @@ type WaitingCloseChannel struct {
 }
 
 // PendingChannels returns a list of lnd's pending channels.
-func (s *lightningClient) PendingChannels(ctx context.Context) (*PendingChannels,
-	error) {
+func (s *lightningClient) PendingChannels(
+	ctx context.Context) (*PendingChannels, error) {
 
 	rpcCtx, cancel := context.WithTimeout(ctx, s.timeout)
 	defer cancel()
@@ -2182,9 +2189,16 @@ func (s *lightningClient) PendingChannels(ctx context.Context) (*PendingChannels
 	}
 
 	pending := &PendingChannels{
-		PendingForceClose: make([]ForceCloseChannel, len(resp.PendingForceClosingChannels)),
-		PendingOpen:       make([]PendingChannel, len(resp.PendingOpenChannels)),
-		WaitingClose:      make([]WaitingCloseChannel, len(resp.WaitingCloseChannels)),
+		PendingForceClose: make(
+			[]ForceCloseChannel,
+			len(resp.PendingForceClosingChannels),
+		),
+		PendingOpen: make(
+			[]PendingChannel, len(resp.PendingOpenChannels),
+		),
+		WaitingClose: make(
+			[]WaitingCloseChannel, len(resp.WaitingCloseChannels),
+		),
 	}
 
 	for i, force := range resp.PendingForceClosingChannels {
@@ -3053,8 +3067,8 @@ func (s *lightningClient) getOpenStatusUpdate(
 // OpenChannelStream opens a channel to the specified peer and with the
 // specified arguments and options. This function returns a stream of
 // updates.
-func (s *lightningClient) OpenChannelStream(ctx context.Context, peer route.Vertex,
-	localSat, pushSat btcutil.Amount, private bool,
+func (s *lightningClient) OpenChannelStream(ctx context.Context,
+	peer route.Vertex, localSat, pushSat btcutil.Amount, private bool,
 	opts ...OpenChannelOption) (<-chan *OpenStatusUpdate, <-chan error,
 	error) {
 

--- a/lightning_client.go
+++ b/lightning_client.go
@@ -3302,6 +3302,7 @@ func (s *lightningClient) CloseChannel(ctx context.Context,
 	return updateChan, errChan, nil
 }
 
+// InboundFee holds the inbound fee policy for a channel.
 type InboundFee struct {
 	// BaseFeeMsat is the inbound base fee charged regardless of the number
 	// of milli-satoshis received in the channel. By default, only negative

--- a/macaroon_pouch.go
+++ b/macaroon_pouch.go
@@ -75,7 +75,9 @@ func newSerializedMacaroon(macaroonPath string) (serializedMacaroon, error) {
 // WithMacaroonAuth modifies the passed context to include the macaroon KV
 // metadata of the target macaroon. This method can be used to add the macaroon
 // at call time, rather than when the connection to the gRPC server is created.
-func (s serializedMacaroon) WithMacaroonAuth(ctx context.Context) context.Context {
+func (s serializedMacaroon) WithMacaroonAuth(
+	ctx context.Context) context.Context {
+
 	return metadata.AppendToOutgoingContext(ctx, "macaroon", string(s))
 }
 
@@ -86,8 +88,8 @@ type macaroonPouch map[LnrpcServiceMac]serializedMacaroon
 
 // newMacaroonPouch returns a new instance of a fully populated macaroonPouch
 // given the directory where all the macaroons are stored.
-func newMacaroonPouch(macaroonDir, customMacPath, customMacHex string) (macaroonPouch,
-	error) {
+func newMacaroonPouch(macaroonDir, customMacPath, customMacHex string) (
+	macaroonPouch, error) {
 
 	// If a custom macaroon is specified, we assume it contains all
 	// permissions needed for the different subservers to function and we

--- a/macaroon_pouch.go
+++ b/macaroon_pouch.go
@@ -13,6 +13,7 @@ import (
 // with a specific lnrpc service.
 type LnrpcServiceMac string
 
+//nolint:revive
 const (
 	AdminServiceMac         LnrpcServiceMac = "admin.macaroon"
 	InvoiceServiceMac       LnrpcServiceMac = "invoices.macaroon"

--- a/macaroon_service.go
+++ b/macaroon_service.go
@@ -28,6 +28,7 @@ const (
 )
 
 var (
+	//nolint:lll
 	// sharedKeyNUMSBytes holds the bytes representing the compressed
 	// byte encoding of SharedKeyNUMS. It was generated via a
 	// try-and-increment approach using the phrase "Shared Secret" with

--- a/signer_client.go
+++ b/signer_client.go
@@ -249,6 +249,7 @@ func marshallSignDescriptors(signDescriptors []*SignDescriptor,
 		return keyDesc
 	}
 
+	//nolint:lll
 	// fullDescriptor is a helper method that creates a fully populated sign
 	// descriptor that includes both the public key and the key locator (if
 	// available). For the locator we explicitly check that both the family

--- a/walletkit_client.go
+++ b/walletkit_client.go
@@ -648,7 +648,7 @@ func unmarshallOutputType(o lnrpc.OutputScriptType) txscript.ScriptClass {
 	}
 }
 
-// RPCTransaction returns a rpc transaction.
+// UnmarshalTransactionDetail returns a rpc transaction.
 func UnmarshalTransactionDetail(tx *lnrpc.Transaction,
 	chainParams *chaincfg.Params) (*lnwallet.TransactionDetail, error) {
 

--- a/walletkit_client.go
+++ b/walletkit_client.go
@@ -434,8 +434,8 @@ func (m *walletKitClient) DeriveNextKey(ctx context.Context, family int32) (
 	}, nil
 }
 
-func (m *walletKitClient) DeriveKey(ctx context.Context, in *keychain.KeyLocator) (
-	*keychain.KeyDescriptor, error) {
+func (m *walletKitClient) DeriveKey(ctx context.Context,
+	in *keychain.KeyLocator) (*keychain.KeyDescriptor, error) {
 
 	rpcCtx, cancel := context.WithTimeout(ctx, m.timeout)
 	defer cancel()
@@ -550,8 +550,8 @@ func (m *walletKitClient) SendOutputs(ctx context.Context,
 	return tx, nil
 }
 
-func (m *walletKitClient) EstimateFeeRate(ctx context.Context, confTarget int32) (
-	chainfee.SatPerKWeight, error) {
+func (m *walletKitClient) EstimateFeeRate(ctx context.Context,
+	confTarget int32) (chainfee.SatPerKWeight, error) {
 
 	rpcCtx, cancel := context.WithTimeout(ctx, m.timeout)
 	defer cancel()


### PR DESCRIPTION
We enable linter caching, enable and fix the long line linter (https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#80-character-line-length) as well as add some rules concerning exported symbols (https://github.com/lightningnetwork/lnd/blob/master/docs/development_guidelines.md#code-documentation-and-commenting).