### PR TITLE
lndclient: expose peer alias

### DIFF
--- a/lightning_client.go
+++ b/lightning_client.go
@@ -465,6 +465,9 @@ type ChannelInfo struct {
 	// CustomChannelData is an optional field that can be used to store
 	// data for custom channels.
 	CustomChannelData []byte
+
+	// PeerAlias is the alias of the peer node.
+	PeerAlias string
 }
 
 func (s *lightningClient) newChannelInfo(channel *lnrpc.Channel) (*ChannelInfo,
@@ -509,6 +512,7 @@ func (s *lightningClient) newChannelInfo(channel *lnrpc.Channel) (*ChannelInfo,
 		ZeroConf:          channel.ZeroConf,
 		ZeroConfScid:      channel.ZeroConfConfirmedScid,
 		CustomChannelData: channel.CustomChannelData,
+		PeerAlias:         channel.PeerAlias,
 	}
 
 	chanInfo.AliasScids = make([]uint64, len(channel.AliasScids))


### PR DESCRIPTION
With this PR we expose the peer alias, which is useful when calling ListChannels, for example.

#### Pull Request Checklist

- [x] PR is opened against correct version branch.
- [x] Version compatibility matrix in the README and minimal required version
      in `lnd_services.go` are updated.
- [x] Update `macaroon_recipes.go` if your PR adds a new method that is called
  differently than the RPC method it invokes.
