### PR TITLE
lndclient: silence expected close error on shutdown

### DIFF
--- a/lnd_services.go
+++ b/lnd_services.go
@@ -332,7 +332,15 @@ func NewLndServices(cfg *LndServicesConfig) (*GrpcLndServices, error) {
 
 	cleanupConn := func() {
 		closeErr := conn.Close()
-		if closeErr != nil {
+		switch {
+		case closeErr == nil:
+			// No error.
+
+		case errors.Is(closeErr, grpc.ErrClientConnClosing):
+			log.Debugf("LND connection is already closing: %v",
+				closeErr)
+
+		default:
 			log.Errorf("Error closing lnd connection: %v", closeErr)
 		}
 	}


### PR DESCRIPTION
During planned termination, conn.Close() can return [ErrClientConnClosing from gRPC package](https://pkg.go.dev/google.golang.org/grpc#pkg-variables). This is expected and should not be logged as an error. Downgrade that case to debug so logs stay clean during shutdown.

Original log line:
```
[ERR] LNDC: Error closing lnd connection: rpc error: code = Canceled desc = grpc: the client connection is closing
```

#### Pull Request Checklist

- [ ] PR is opened against correct version branch.
- [ ] Version compatibility matrix in the README and minimal required version
      in `lnd_services.go` are updated.
- [ ] Update `macaroon_recipes.go` if your PR adds a new method that is called
  differently than the RPC method it invokes.
