### PR TITLE
lndclient: add channel state update events

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ defaults:
     shell: bash
 
 env:
-  GO_VERSION: 1.24.6
+  GO_VERSION: 1.26
 
 jobs:
   build:

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/btcsuite/btclog/v2 v2.0.1-0.20250728225537-6090e87c6c5b
 	github.com/btcsuite/btcwallet v0.16.17
 	github.com/btcsuite/btcwallet/wtxmgr v1.5.6
-	github.com/lightningnetwork/lnd v0.20.0-beta.rc4.0.20260110233730-15227a4ff50a
+	github.com/lightningnetwork/lnd v0.20.0-beta.rc4.0.20260223110936-dd65ba2b0106
 	github.com/lightningnetwork/lnd/kvdb v1.4.16
 	github.com/stretchr/testify v1.10.0
 	google.golang.org/grpc v1.59.0
@@ -103,7 +103,7 @@ require (
 	github.com/lightningnetwork/lnd/fn/v2 v2.0.9 // indirect
 	github.com/lightningnetwork/lnd/healthcheck v1.2.6 // indirect
 	github.com/lightningnetwork/lnd/queue v1.1.1 // indirect
-	github.com/lightningnetwork/lnd/sqldb v1.0.12 // indirect
+	github.com/lightningnetwork/lnd/sqldb v1.0.13-0.20260223110936-dd65ba2b0106 // indirect
 	github.com/lightningnetwork/lnd/ticker v1.1.1 // indirect
 	github.com/lightningnetwork/lnd/tlv v1.3.2 // indirect
 	github.com/lightningnetwork/lnd/tor v1.1.6 // indirect

--- a/go.mod
+++ b/go.mod
@@ -193,4 +193,4 @@ require (
 // allows us to specify that as an option.
 replace google.golang.org/protobuf => github.com/lightninglabs/protobuf-go-hex-display v1.33.0-hex-display
 
-go 1.24.9
+go 1.25.5

--- a/go.sum
+++ b/go.sum
@@ -356,8 +356,8 @@ github.com/lightninglabs/protobuf-go-hex-display v1.33.0-hex-display h1:Y2WiPkBS
 github.com/lightninglabs/protobuf-go-hex-display v1.33.0-hex-display/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 github.com/lightningnetwork/lightning-onion v1.2.1-0.20240815225420-8b40adf04ab9 h1:6D3LrdagJweLLdFm1JNodZsBk6iU4TTsBBFLQ4yiXfI=
 github.com/lightningnetwork/lightning-onion v1.2.1-0.20240815225420-8b40adf04ab9/go.mod h1:EDqJ3MuZIbMq0QI1czTIKDJ/GS8S14RXPwapHw8cw6w=
-github.com/lightningnetwork/lnd v0.20.0-beta.rc4.0.20260110233730-15227a4ff50a h1:iRR8gWsS7rPTz7GRmyBu/QU0kXBAPi/FYxfnrhuh9Y4=
-github.com/lightningnetwork/lnd v0.20.0-beta.rc4.0.20260110233730-15227a4ff50a/go.mod h1:OycW7yPCaApWsIqLthe8QHxk4dM5wOw0LPcUXjr3a5s=
+github.com/lightningnetwork/lnd v0.20.0-beta.rc4.0.20260223110936-dd65ba2b0106 h1:2WFtZbLXZowrPoM4dsiYWYqGHyv7D1fpQRp8HoQ86co=
+github.com/lightningnetwork/lnd v0.20.0-beta.rc4.0.20260223110936-dd65ba2b0106/go.mod h1:ybhzpoSuWJmTENgFS9N8pXnY9VCHwh07Lqygh1Pzjqw=
 github.com/lightningnetwork/lnd/clock v1.1.1 h1:OfR3/zcJd2RhH0RU+zX/77c0ZiOnIMsDIBjgjWdZgA0=
 github.com/lightningnetwork/lnd/clock v1.1.1/go.mod h1:mGnAhPyjYZQJmebS7aevElXKTFDuO+uNFFfMXK1W8xQ=
 github.com/lightningnetwork/lnd/fn/v2 v2.0.9 h1:ZytG4ltPac/sCyg1EJDn10RGzPIDJeyennUMRdOw7Y8=
@@ -368,8 +368,8 @@ github.com/lightningnetwork/lnd/kvdb v1.4.16 h1:9BZgWdDfjmHRHLS97cz39bVuBAqMc4/p
 github.com/lightningnetwork/lnd/kvdb v1.4.16/go.mod h1:HW+bvwkxNaopkz3oIgBV6NEnV4jCEZCACFUcNg4xSjM=
 github.com/lightningnetwork/lnd/queue v1.1.1 h1:99ovBlpM9B0FRCGYJo6RSFDlt8/vOkQQZznVb18iNMI=
 github.com/lightningnetwork/lnd/queue v1.1.1/go.mod h1:7A6nC1Qrm32FHuhx/mi1cieAiBZo5O6l8IBIoQxvkz4=
-github.com/lightningnetwork/lnd/sqldb v1.0.12 h1:cNJsL+ymCtTn9DqroszZixKaD96GN32ujpHUYvrkN30=
-github.com/lightningnetwork/lnd/sqldb v1.0.12/go.mod h1:Ic65SUa2pJzc3sWSZqDTrWo5qdKIS1zu/blhSddF7X8=
+github.com/lightningnetwork/lnd/sqldb v1.0.13-0.20260223110936-dd65ba2b0106 h1:9XT9sZhdwUOjCb6GTvqOpgaCalrEH4mqDQOhOs+IoZc=
+github.com/lightningnetwork/lnd/sqldb v1.0.13-0.20260223110936-dd65ba2b0106/go.mod h1:XaG3d8AR7/e6+HUw5jvNvm+gs6MowB+iE9myFH8Rc14=
 github.com/lightningnetwork/lnd/ticker v1.1.1 h1:J/b6N2hibFtC7JLV77ULQp++QLtCwT6ijJlbdiZFbSM=
 github.com/lightningnetwork/lnd/ticker v1.1.1/go.mod h1:waPTRAAcwtu7Ji3+3k+u/xH5GHovTsCoSVpho0KDvdA=
 github.com/lightningnetwork/lnd/tlv v1.3.2 h1:MO4FCk7F4k5xPMqVZF6Nb/kOpxlwPrUQpYjmyKny5s0=

--- a/lightning_client.go
+++ b/lightning_client.go
@@ -609,6 +609,9 @@ const (
 	// FullyResolvedChannelUpdate indicates that the channel event holds
 	// information about a channel has been fully closed.
 	FullyResolvedChannelUpdate
+
+	// StateChannelUpdate indicates that the channel state has been updated.
+	StateChannelUpdate
 )
 
 // OpenStatusUpdate is a wrapper for channel status updates following a channel
@@ -649,6 +652,9 @@ type ChannelEventUpdate struct {
 
 	// ClosedChannelInfo holds the channel info for a newly closed channel.
 	ClosedChannelInfo *ClosedChannel
+
+	// UpdatedChannelInfo holds the channel info for channel state updates.
+	UpdatedChannelInfo *ChannelInfo
 }
 
 // ClosedChannel represents a channel that has been closed.
@@ -2829,6 +2835,17 @@ func (s *lightningClient) getChannelEventUpdate(
 		result.ChannelPoint, err = getOutPoint(
 			fundingTxID.FundingTxidBytes,
 			channelPoint.OutputIndex,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+	case lnrpc.ChannelEventUpdate_CHANNEL_UPDATE:
+		result.UpdateType = StateChannelUpdate
+		channel := rpcChannelEventUpdate.GetUpdatedChannel()
+
+		result.UpdatedChannelInfo, err = s.newChannelInfo(
+			channel.Channel,
 		)
 		if err != nil {
 			return nil, err

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.9-bookworm
+FROM golang:1.26.0-bookworm
 
 RUN apt-get update && apt-get install -y git
 ENV GOCACHE=/tmp/build/.cache

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/lightninglabs/lndclient/tools
 
-go 1.24.6
+go 1.25.5
 
 require (
 	// Once golangci-lint v2.4.1 update it here.


### PR DESCRIPTION
Adds channel state updates from https://github.com/lightningnetwork/lnd/pull/10543 to lndclient.

Todo:
- [x] need to update the go.mod once the lnd PR is merged

Note that there is another PR that bumps the version here https://github.com/lightninglabs/lndclient/pull/264, which may lead to merge conflicts once we merge `lnd-21-0`, but I think they are easy to handle.