### PR TITLE
lndclient: add FailureMessage and FailureCode to InterceptedHtlcResponse

### DIFF
--- a/router_client.go
+++ b/router_client.go
@@ -395,6 +395,19 @@ type InterceptedHtlcResponse struct {
 	// intercepted.
 	Action InterceptorAction
 
+	// FailureMessage is a pre-encrypted onion error to return when the
+	// action is fail. When set, lnd relays the bytes using
+	// IntermediateEncrypt, preserving the error attribution of the
+	// original encrypter.
+	FailureMessage []byte
+
+	// FailureCode is the failure code to return when the action is
+	// fail. When non-zero, lnd constructs an onion error attributed to
+	// the intercepting node using EncryptFirstHop. When zero and
+	// FailureMessage is also empty, lnd defaults to
+	// TemporaryChannelFailure.
+	FailureCode lnrpc.Failure_FailureCode
+
 	// IncomingAmount is the amount that should be used to validate the
 	// incoming htlc. This might be different from the actual HTLC amount
 	// for custom channels.
@@ -954,6 +967,22 @@ func rpcInterceptorResponse(request InterceptedHtlc,
 
 	case InterceptorActionFail:
 		rpcResp.Action = routerrpc.ResolveHoldForwardAction_FAIL
+
+		if len(response.FailureMessage) > 0 &&
+			response.FailureCode != 0 {
+
+			return nil, errors.New(
+				"failure_message and failure_code are " +
+					"mutually exclusive",
+			)
+		}
+
+		if len(response.FailureMessage) > 0 {
+			rpcResp.FailureMessage = response.FailureMessage
+		}
+		if response.FailureCode != 0 {
+			rpcResp.FailureCode = response.FailureCode
+		}
 
 	case InterceptorActionResume:
 		rpcResp.Action = routerrpc.ResolveHoldForwardAction_RESUME


### PR DESCRIPTION
## Description

The `routerrpc` HTLC interception API in **_lnd_** already supports `failure_message` and `failure_code` on `ForwardHtlcInterceptResponse`, but **_lndclient_** never exposed them. This PR brings the library in line with the proto by adding `FailureMessage` and `FailureCode` to `InterceptedHtlcResponse` and wiring them through `rpcInterceptorResponse`.

`FailureMessage` accepts a pre-encrypted onion error blob. When set, **_lnd_** relays the bytes through `IntermediateEncrypt` rather than constructing a new error with `EncryptFirstHop`. This allows a virtual node behind the interceptor to produce errors attributed to itself instead of the intercepting node.

`FailureCode` selects a specific failure code for errors that **_lnd_** constructs on behalf of the intercepting node. Without either field, **_lnd_** defaults to `TemporaryChannelFailure`.

#### Pull Request Checklist
- [ ] PR is opened against correct version branch.
- [ ] Version compatibility matrix in the README and minimal required version
      in `lnd_services.go` are updated.
- [ ] Update `macaroon_recipes.go` if your PR adds a new method that is called
  differently than the RPC method it invokes.
