### PR TITLE
lndclient: handle SIMPLE_TAPROOT_FINAL in acceptor request

### DIFF
--- a/lightning_client.go
+++ b/lightning_client.go
@@ -1182,6 +1182,10 @@ func newAcceptorRequest(req *lnrpc.ChannelAcceptRequest) (*AcceptorRequest,
 		commitmentType = new(lnwallet.CommitmentType)
 		*commitmentType = lnwallet.CommitmentTypeSimpleTaproot
 
+	case lnrpc.CommitmentType_SIMPLE_TAPROOT_FINAL:
+		commitmentType = new(lnwallet.CommitmentType)
+		*commitmentType = lnwallet.CommitmentTypeSimpleTaprootFinal
+
 	case lnrpc.CommitmentType_SIMPLE_TAPROOT_OVERLAY:
 		commitmentType = new(lnwallet.CommitmentType)
 		*commitmentType = lnwallet.CommitmentTypeSimpleTaprootOverlay


### PR DESCRIPTION
In this PR, we add the missing `SIMPLE_TAPROOT_FINAL` case to the
acceptor request translator in `lightning_client.go`. Today the switch
in `newAcceptorRequest` handles `SIMPLE_TAPROOT` (staging bits) and
`SIMPLE_TAPROOT_OVERLAY`, but the production taproot type added in
lnd v0.21 falls through to the default arm and is rejected with
`unhandled commitment type 7`. Any node running an lndclient-backed
acceptor (loop, tapd, custom integrations) would silently refuse every
inbound production taproot open, which becomes a real problem now that
[lightningnetwork/lnd#10820](https://github.com/lightningnetwork/lnd/pull/10820)
makes the production variant the one users actually pick.

The fix is a single case that maps `SIMPLE_TAPROOT_FINAL` to
`lnwallet.CommitmentTypeSimpleTaprootFinal`, so the new variant reaches
the acceptor callback the same way as the staging and overlay variants
already do.

Targeted at `lnd-21-0` since `SIMPLE_TAPROOT_FINAL` only exists in the
lnd v0.21 RPC surface, and that branch already pins
`lnd v0.21.0-beta.rc1`.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...`
- [ ] Manual: stand up a node with an lndclient-backed acceptor, drive
  an inbound `OpenChannel` with `CommitmentType_SIMPLE_TAPROOT_FINAL`,
  confirm it reaches the acceptor callback instead of erroring out with
  `unhandled commitment type 7`.