### PR TITLE
chainnotifier: surface re-org depth and Done events

### DIFF
--- a/chainnotifier_client.go
+++ b/chainnotifier_client.go
@@ -14,7 +14,9 @@ import (
 )
 
 // NotifierOptions is a set of functional options that allow callers to further
-// modify the type of chain even notifications they receive.
+// modify the type of chain event notifications they receive. Signal delivery
+// waits for the caller or context cancellation, so callers must receive from
+// every channel they configure.
 type NotifierOptions struct {
 	// IncludeBlock if true, then the dispatched confirmation notification
 	// will include the block that mined the transaction.
@@ -27,6 +29,21 @@ type NotifierOptions struct {
 	// the passed in context to cancel being notified once the required
 	// number of confirmations have been reached.
 	ReOrgChan chan struct{}
+
+	// ReOrgDepthChan if set, will be sent the depth of a re-org whenever
+	// the transaction is re-organized out of the chain. It carries the same
+	// signal as ReOrgChan but with the re-org depth attached. Only
+	// confirmation notifications populate a depth; spend notifications send
+	// 0. Like ReOrgChan, setting this keeps the notification listener alive
+	// past the first event.
+	ReOrgDepthChan chan int32
+
+	// DoneChan if set, will be sent on once the notification is no longer
+	// under the risk of being re-organized out of the chain, i.e. it has
+	// reached the backend's re-org safety depth. Setting this keeps the
+	// notification listener alive past the first event so the terminal Done
+	// signal can be delivered.
+	DoneChan chan struct{}
 }
 
 // DefaultNotifierOptions returns the set of default options for the notifier.
@@ -55,6 +72,27 @@ func WithIncludeBlock() NotifierOption {
 func WithReOrgChan(reOrgChan chan struct{}) NotifierOption {
 	return func(o *NotifierOptions) {
 		o.ReOrgChan = reOrgChan
+	}
+}
+
+// WithReOrgDepthChan configures a channel that will be sent the depth of a
+// re-org whenever the transaction/spend is re-organized out of the chain. Like
+// WithReOrgChan, setting this keeps the notification listener alive past the
+// first event, so the caller must cancel the passed in context to stop being
+// notified. Only confirmation notifications populate a non-zero depth.
+func WithReOrgDepthChan(reOrgDepthChan chan int32) NotifierOption {
+	return func(o *NotifierOptions) {
+		o.ReOrgDepthChan = reOrgDepthChan
+	}
+}
+
+// WithDoneChan configures a channel that will be sent on once the notification
+// has reached the backend's re-org safety depth and is therefore complete.
+// Setting this keeps the notification listener alive past the first event so
+// the terminal Done signal can be delivered.
+func WithDoneChan(doneChan chan struct{}) NotifierOption {
+	return func(o *NotifierOptions) {
+		o.DoneChan = doneChan
 	}
 }
 
@@ -178,16 +216,15 @@ func (s *chainNotifierClient) RegisterSpendNtfn(ctx context.Context,
 		}
 	}
 
-	processReorg := func() {
-		if opts.ReOrgChan == nil {
-			return
-		}
+	// reorgAware reports whether the caller asked to keep the listener
+	// alive past the first event to observe re-orgs or the terminal Done
+	// signal.
+	reorgAware := opts.ReOrgChan != nil || opts.ReOrgDepthChan != nil ||
+		opts.DoneChan != nil
 
-		select {
-		case opts.ReOrgChan <- struct{}{}:
-		case <-ctx.Done():
-			return
-		}
+	processReorg := func(depth int32) {
+		deliver(ctx, opts.ReOrgChan, struct{}{})
+		deliver(ctx, opts.ReOrgDepthChan, depth)
 	}
 
 	s.wg.Add(1)
@@ -213,12 +250,21 @@ func (s *chainNotifierClient) RegisterSpendNtfn(ctx context.Context,
 				// we don't return here, since we might want to
 				// be informed about the new block we got
 				// confirmed in after a re-org.
-				if opts.ReOrgChan == nil {
+				if !reorgAware {
 					return
 				}
 
 			case *chainrpc.SpendEvent_Reorg:
-				processReorg()
+				// The spend notifier does not track re-org
+				// depth, so a depth of 0 is forwarded.
+				processReorg(0)
+
+			// The spend has reached the backend's re-org safety
+			// depth: deliver the terminal Done signal and stop.
+			case *chainrpc.SpendEvent_Done:
+				deliver(ctx, opts.DoneChan, struct{}{})
+
+				return
 
 			// Nil event, should never happen.
 			case nil:
@@ -235,6 +281,20 @@ func (s *chainNotifierClient) RegisterSpendNtfn(ctx context.Context,
 	}()
 
 	return spendChan, errChan, nil
+}
+
+// deliver sends v on ch if ch is non-nil. The send is bounded by the
+// registration context, so callers must read every channel they configure or
+// cancel the context.
+func deliver[T any](ctx context.Context, ch chan T, v T) {
+	if ch == nil {
+		return
+	}
+
+	select {
+	case ch <- v:
+	case <-ctx.Done():
+	}
 }
 
 func (s *chainNotifierClient) RegisterConfirmationsNtfn(ctx context.Context,
@@ -266,6 +326,12 @@ func (s *chainNotifierClient) RegisterConfirmationsNtfn(ctx context.Context,
 
 	confChan := make(chan *chainntnfs.TxConfirmation, 1)
 	errChan := make(chan error, 1)
+
+	// reorgAware reports whether the caller asked to keep the listener
+	// alive past the first confirmation to observe re-orgs or the terminal
+	// Done signal.
+	reorgAware := opts.ReOrgChan != nil || opts.ReOrgDepthChan != nil ||
+		opts.DoneChan != nil
 
 	s.wg.Add(1)
 	go func() {
@@ -325,22 +391,27 @@ func (s *chainNotifierClient) RegisterConfirmationsNtfn(ctx context.Context,
 				// we don't return here, since we might want to
 				// be informed about the new block we got
 				// confirmed in after a re-org.
-				if opts.ReOrgChan == nil {
+				if !reorgAware {
 					return
 				}
 
-			// On a re-org, we just need to signal, we don't have
-			// any additional information. But we only signal if the
-			// caller requested to be notified about re-orgs.
+			// On a re-org, we signal and forward the re-org depth,
+			// but only if the caller requested to be notified.
 			case *chainrpc.ConfEvent_Reorg:
-				if opts.ReOrgChan != nil {
-					select {
-					case opts.ReOrgChan <- struct{}{}:
-					case <-ctx.Done():
-						return
-					}
-				}
+				deliver(ctx, opts.ReOrgChan, struct{}{})
+				deliver(
+					ctx, opts.ReOrgDepthChan,
+					int32(c.Reorg.Depth),
+				)
 				continue
+
+			// The confirmation has reached the backend's re-org
+			// safety depth: deliver the terminal Done signal and
+			// stop.
+			case *chainrpc.ConfEvent_Done:
+				deliver(ctx, opts.DoneChan, struct{}{})
+
+				return
 
 			// Nil event, should never happen.
 			case nil:

--- a/chainnotifier_client_test.go
+++ b/chainnotifier_client_test.go
@@ -1,0 +1,326 @@
+package lndclient
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/lightningnetwork/lnd/lnrpc/chainrpc"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+type scriptedConfStream struct {
+	grpc.ClientStream
+
+	events    []*chainrpc.ConfEvent
+	recvCalls int
+}
+
+func (s *scriptedConfStream) Recv() (*chainrpc.ConfEvent, error) {
+	s.recvCalls++
+	if len(s.events) == 0 {
+		return nil, io.EOF
+	}
+
+	event := s.events[0]
+	s.events = s.events[1:]
+
+	return event, nil
+}
+
+type scriptedSpendStream struct {
+	grpc.ClientStream
+
+	events    []*chainrpc.SpendEvent
+	recvCalls int
+}
+
+func (s *scriptedSpendStream) Recv() (*chainrpc.SpendEvent, error) {
+	s.recvCalls++
+	if len(s.events) == 0 {
+		return nil, io.EOF
+	}
+
+	event := s.events[0]
+	s.events = s.events[1:]
+
+	return event, nil
+}
+
+type mockChainNotifierRPC struct {
+	confStream  chainrpc.ChainNotifier_RegisterConfirmationsNtfnClient
+	spendStream chainrpc.ChainNotifier_RegisterSpendNtfnClient
+}
+
+func (m *mockChainNotifierRPC) RegisterConfirmationsNtfn(context.Context,
+	*chainrpc.ConfRequest, ...grpc.CallOption) (
+	chainrpc.ChainNotifier_RegisterConfirmationsNtfnClient, error) {
+
+	if m.confStream == nil {
+		return nil, fmt.Errorf("unexpected confirmation registration")
+	}
+
+	return m.confStream, nil
+}
+
+func (m *mockChainNotifierRPC) RegisterSpendNtfn(context.Context,
+	*chainrpc.SpendRequest, ...grpc.CallOption) (
+	chainrpc.ChainNotifier_RegisterSpendNtfnClient, error) {
+
+	if m.spendStream == nil {
+		return nil, fmt.Errorf("unexpected spend registration")
+	}
+
+	return m.spendStream, nil
+}
+
+func (m *mockChainNotifierRPC) RegisterBlockEpochNtfn(context.Context,
+	*chainrpc.BlockEpoch, ...grpc.CallOption) (
+	chainrpc.ChainNotifier_RegisterBlockEpochNtfnClient, error) {
+
+	return nil, fmt.Errorf("unexpected block epoch registration")
+}
+
+// testTxBytes returns a serialized transaction suitable for notifier events.
+func testTxBytes(t *testing.T) []byte {
+	t.Helper()
+
+	tx := wire.NewMsgTx(2)
+	tx.AddTxIn(&wire.TxIn{})
+	tx.AddTxOut(&wire.TxOut{
+		Value:    1000,
+		PkScript: []byte{0x51},
+	})
+
+	var txBuf bytes.Buffer
+	require.NoError(t, tx.Serialize(&txBuf))
+
+	return txBuf.Bytes()
+}
+
+// confEvent returns a valid confirmation event at the given height.
+func confEvent(t *testing.T, height uint32) *chainrpc.ConfEvent {
+	t.Helper()
+
+	return &chainrpc.ConfEvent{
+		Event: &chainrpc.ConfEvent_Conf{
+			Conf: &chainrpc.ConfDetails{
+				RawTx:       testTxBytes(t),
+				BlockHash:   make([]byte, chainhash.HashSize),
+				BlockHeight: height,
+			},
+		},
+	}
+}
+
+// spendEvent returns a valid spend event at the given height.
+func spendEvent(t *testing.T, height uint32) *chainrpc.SpendEvent {
+	t.Helper()
+
+	return &chainrpc.SpendEvent{
+		Event: &chainrpc.SpendEvent_Spend{
+			Spend: &chainrpc.SpendDetails{
+				SpendingOutpoint: &chainrpc.Outpoint{
+					Hash: make([]byte, chainhash.HashSize),
+				},
+				RawSpendingTx:  testTxBytes(t),
+				SpendingTxHash: make([]byte, chainhash.HashSize),
+				SpendingHeight: height,
+			},
+		},
+	}
+}
+
+// TestConfirmationLifecycle verifies that confirmation, re-org depth,
+// reconfirmation, and finality are all surfaced in order.
+func TestConfirmationLifecycle(t *testing.T) {
+	t.Parallel()
+
+	stream := &scriptedConfStream{
+		events: []*chainrpc.ConfEvent{
+			confEvent(t, 100),
+			{
+				Event: &chainrpc.ConfEvent_Reorg{
+					Reorg: &chainrpc.Reorg{Depth: 7},
+				},
+			},
+			confEvent(t, 102),
+			{
+				Event: &chainrpc.ConfEvent_Done{
+					Done: &chainrpc.Done{},
+				},
+			},
+		},
+	}
+	client := &chainNotifierClient{
+		client: &mockChainNotifierRPC{confStream: stream},
+	}
+
+	reorgChan := make(chan struct{}, 1)
+	depthChan := make(chan int32, 1)
+	doneChan := make(chan struct{}, 1)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	confs, errs, err := client.RegisterConfirmationsNtfn(
+		ctx, nil, []byte{0x51}, 1, 1,
+		WithReOrgChan(reorgChan), WithReOrgDepthChan(depthChan),
+		WithDoneChan(doneChan),
+	)
+	require.NoError(t, err)
+
+	select {
+	case conf := <-confs:
+		require.EqualValues(t, 100, conf.BlockHeight)
+	case <-ctx.Done():
+		t.Fatal("confirmation lifecycle timed out")
+	}
+	select {
+	case <-reorgChan:
+	case <-ctx.Done():
+		t.Fatal("confirmation re-org signal timed out")
+	}
+	select {
+	case depth := <-depthChan:
+		require.EqualValues(t, 7, depth)
+	case <-ctx.Done():
+		t.Fatal("confirmation re-org depth timed out")
+	}
+	select {
+	case conf := <-confs:
+		require.EqualValues(t, 102, conf.BlockHeight)
+	case <-ctx.Done():
+		t.Fatal("reconfirmation timed out")
+	}
+	select {
+	case <-doneChan:
+	case <-ctx.Done():
+		t.Fatal("confirmation Done signal timed out")
+	}
+
+	client.WaitForFinished()
+	require.Equal(t, 4, stream.recvCalls)
+	select {
+	case err := <-errs:
+		require.NoError(t, err)
+	default:
+	}
+}
+
+// TestSpendLifecycle verifies that spend, re-org, replacement spend, and
+// finality are all surfaced in order. Spend notifications report depth zero.
+func TestSpendLifecycle(t *testing.T) {
+	t.Parallel()
+
+	stream := &scriptedSpendStream{
+		events: []*chainrpc.SpendEvent{
+			spendEvent(t, 100),
+			{
+				Event: &chainrpc.SpendEvent_Reorg{
+					Reorg: &chainrpc.Reorg{},
+				},
+			},
+			spendEvent(t, 102),
+			{
+				Event: &chainrpc.SpendEvent_Done{
+					Done: &chainrpc.Done{},
+				},
+			},
+		},
+	}
+	client := &chainNotifierClient{
+		client: &mockChainNotifierRPC{spendStream: stream},
+	}
+
+	reorgChan := make(chan struct{}, 1)
+	depthChan := make(chan int32, 1)
+	doneChan := make(chan struct{}, 1)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	spends, errs, err := client.RegisterSpendNtfn(
+		ctx, nil, []byte{0x51}, 1, WithReOrgChan(reorgChan),
+		WithReOrgDepthChan(depthChan), WithDoneChan(doneChan),
+	)
+	require.NoError(t, err)
+
+	select {
+	case spend := <-spends:
+		require.EqualValues(t, 100, spend.SpendingHeight)
+	case <-ctx.Done():
+		t.Fatal("spend lifecycle timed out")
+	}
+	select {
+	case <-reorgChan:
+	case <-ctx.Done():
+		t.Fatal("spend re-org signal timed out")
+	}
+	select {
+	case depth := <-depthChan:
+		require.Zero(t, depth)
+	case <-ctx.Done():
+		t.Fatal("spend re-org depth timed out")
+	}
+	select {
+	case spend := <-spends:
+		require.EqualValues(t, 102, spend.SpendingHeight)
+	case <-ctx.Done():
+		t.Fatal("replacement spend timed out")
+	}
+	select {
+	case <-doneChan:
+	case <-ctx.Done():
+		t.Fatal("spend Done signal timed out")
+	}
+
+	client.WaitForFinished()
+	require.Equal(t, 4, stream.recvCalls)
+	select {
+	case err := <-errs:
+		require.NoError(t, err)
+	default:
+	}
+}
+
+// TestNotifierLegacySingleEvent verifies that callers which do not request
+// lifecycle events retain the existing first-positive-event behavior.
+func TestNotifierLegacySingleEvent(t *testing.T) {
+	t.Parallel()
+
+	stream := &scriptedConfStream{
+		events: []*chainrpc.ConfEvent{
+			confEvent(t, 100), confEvent(t, 101),
+		},
+	}
+	client := &chainNotifierClient{
+		client: &mockChainNotifierRPC{confStream: stream},
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	confs, errs, err := client.RegisterConfirmationsNtfn(
+		ctx, nil, []byte{0x51}, 1, 1,
+	)
+	require.NoError(t, err)
+
+	select {
+	case conf := <-confs:
+		require.EqualValues(t, 100, conf.BlockHeight)
+	case <-ctx.Done():
+		t.Fatal("legacy confirmation timed out")
+	}
+
+	client.WaitForFinished()
+	require.Equal(t, 1, stream.recvCalls)
+	select {
+	case err := <-errs:
+		require.NoError(t, err)
+	default:
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -199,3 +199,5 @@ require (
 replace google.golang.org/protobuf => github.com/lightninglabs/protobuf-go-hex-display v1.33.0-hex-display
 
 go 1.25.11
+
+replace github.com/lightningnetwork/lnd => github.com/ellemouton/lnd v0.8.0-beta-rc3.0.20260716172607-ed0a3dda2599

--- a/go.sum
+++ b/go.sum
@@ -111,6 +111,8 @@ github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
+github.com/ellemouton/lnd v0.8.0-beta-rc3.0.20260716172607-ed0a3dda2599 h1:N6CQ5kbJ/wSh1A1zvA6+pGK8qr+TakRNo0fqYt7RmnA=
+github.com/ellemouton/lnd v0.8.0-beta-rc3.0.20260716172607-ed0a3dda2599/go.mod h1:LWfQaNNXlZghUJqIIh+JsgfxiVtC+ecZkrIe5bm9o4U=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
@@ -279,8 +281,6 @@ github.com/lightninglabs/protobuf-go-hex-display v1.33.0-hex-display h1:Y2WiPkBS
 github.com/lightninglabs/protobuf-go-hex-display v1.33.0-hex-display/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 github.com/lightningnetwork/lightning-onion v1.4.0 h1:qWE1icOH4AKXRcq1KCzt6P/TesqptgBTP++V7wowTc0=
 github.com/lightningnetwork/lightning-onion v1.4.0/go.mod h1:YDPkvVTVQ6FBBE6Yj93tDd7zA3iTSrryi9xq46i7bKE=
-github.com/lightningnetwork/lnd v0.21.0-beta.rc2.0.20260630214209-40c64f9db30d h1:mDcB9mwuwJXRbDmxps6mBgGs318Iz5ZbOrt0ieEx0os=
-github.com/lightningnetwork/lnd v0.21.0-beta.rc2.0.20260630214209-40c64f9db30d/go.mod h1:LWfQaNNXlZghUJqIIh+JsgfxiVtC+ecZkrIe5bm9o4U=
 github.com/lightningnetwork/lnd/actor v0.0.6 h1:Ge8N2wivARG+27qJBwTlB0vwsypStZYZy8vk4Zl38sU=
 github.com/lightningnetwork/lnd/actor v0.0.6/go.mod h1:YAsoniSbY/cAM9HTVNfZLvt7RI6swDxy6wzPspTcMZg=
 github.com/lightningnetwork/lnd/clock v1.1.1 h1:OfR3/zcJd2RhH0RU+zX/77c0ZiOnIMsDIBjgjWdZgA0=


### PR DESCRIPTION
## Summary

Surfaces the reversible `ChainNotifier` lifecycle added by
[lightningnetwork/lnd#10943](https://github.com/lightningnetwork/lnd/pull/10943):

```
positive → reorg(depth) → positive → Done
```

Previously lndclient only exposed a payload-less re-org ping and had no
unambiguous finality event. In particular, stream completion alone could not
distinguish policy finality from transport teardown.

## Changes

- Add `WithReOrgDepthChan(chan int32)`:
  - confirmation notifications deliver lnd's native re-org depth;
  - spend notifications deliver `0`, because lnd does not currently track
    spend re-org depth.
- Add `WithDoneChan(chan struct{})` for explicit backend policy finality.
- Keep the listener alive past the first positive event when any re-org/depth/
  Done channel is configured, while preserving the legacy first-positive-event
  behavior for callers which configure none of them.
- Handle `ConfEvent_Done` and `SpendEvent_Done`, and stop cleanly after
  delivering the terminal event.
- Document that delivery waits for each configured channel or context
  cancellation, so callers must drain every channel they configure.
- Add scripted transport tests for confirmation and spend
  positive/reorg/positive/Done lifecycles, re-org depth mapping, spend depth
  `0`, terminal completion, and legacy behavior.

## Dependency

This PR is blocked on [lightningnetwork/lnd#10943](https://github.com/lightningnetwork/lnd/pull/10943)
for the additive proto variants. Until that lands and is released, `go.mod`
temporarily replaces lnd with the exact reviewed PR head. The replace should be
removed when lndclient can bump to the released upstream version.

## Validation

- `make build`
- `go test ./...`
- `go test -race ./...`
- `golangci-lint run --new ./...` — 0 issues
