### PR TITLE
walletkit: add RemoveTransaction client method

### DIFF
--- a/testdata/permissions.json
+++ b/testdata/permissions.json
@@ -1168,6 +1168,14 @@
                 }
             ]
         },
+        "/walletrpc.WalletKit/RemoveTransaction": {
+            "permissions": [
+                {
+                    "entity": "onchain",
+                    "action": "write"
+                }
+            ]
+        },
         "/walletrpc.WalletKit/PendingSweeps": {
             "permissions": [
                 {

--- a/walletkit_client.go
+++ b/walletkit_client.go
@@ -106,6 +106,13 @@ type WalletKitClient interface {
 	GetTransaction(ctx context.Context,
 		txid chainhash.Hash) (Transaction, error)
 
+	// RemoveTransaction removes the transaction with the given hash, and
+	// all transactions that depend on it, from the wallet's store and its
+	// unconfirmed-rebroadcast set. It is the programmatic form of
+	// `lncli wallet removetx`, used to stop lnd from perpetually
+	// rebroadcasting a transaction the caller has abandoned.
+	RemoveTransaction(ctx context.Context, txid chainhash.Hash) error
+
 	PublishTransaction(ctx context.Context, tx *wire.MsgTx,
 		label string) error
 
@@ -513,6 +520,28 @@ func (m *walletKitClient) GetTransaction(ctx context.Context,
 	}
 
 	return unmarshallTransaction(resp)
+}
+
+// RemoveTransaction removes the transaction with the given hash, and all
+// transactions that depend on it, from the wallet. This stops lnd from
+// continuing to rebroadcast an unconfirmed transaction the caller no longer
+// wants in the mempool. The underlying RPC reuses GetTransactionRequest to
+// identify the transaction by hash.
+func (m *walletKitClient) RemoveTransaction(ctx context.Context,
+	txid chainhash.Hash) error {
+
+	rpcCtx, cancel := context.WithTimeout(ctx, m.timeout)
+	defer cancel()
+
+	rpcCtx = m.walletKitMac.WithMacaroonAuth(rpcCtx)
+
+	_, err := m.client.RemoveTransaction(
+		rpcCtx, &walletrpc.GetTransactionRequest{
+			Txid: txid.String(),
+		},
+	)
+
+	return err
 }
 
 func (m *walletKitClient) PublishTransaction(ctx context.Context,


### PR DESCRIPTION
Adds `WalletKit.RemoveTransaction` to the lndclient WalletKit surface, wrapping lnd's existing `WalletKit.RemoveTransaction` RPC (`lncli wallet removetx`).

### Motivation

A downstream consumer broadcasts transactions through lnd and, when it abandons one (e.g. a unilateral-exit tree tx that can no longer confirm), needs to stop lnd from perpetually rebroadcasting the now-invalid transaction from its wallet queue. lnd already exposes `RemoveTransaction` for exactly this, but lndclient didn't wrap it.

### Change

- `WalletKitClient.RemoveTransaction(ctx, txid)` — thin wrapper mirroring `GetTransaction` (the RPC reuses `GetTransactionRequest` to identify the transaction by hash, so no new request type is introduced).
- `testdata/permissions.json` — adds the `/walletrpc.WalletKit/RemoveTransaction` entry (`onchain:write`), keeping the static `lncli listpermissions` snapshot faithful. `TestMacaroonRecipe` still passes — the distinct `walletrpc` permission count is unchanged at 3.

`go build ./...`, `gofmt`, and the test suite are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
