### PR TITLE
lndclient: fix decoded payment request expiry

### DIFF
--- a/lightning_client.go
+++ b/lightning_client.go
@@ -2908,8 +2908,8 @@ type PaymentRequest struct {
 	// Timestamp of the payment request.
 	Timestamp time.Time
 
-	// Expiry is the time at which the payment request expires.
-	Expiry time.Time
+	// ExpiresAt is the time at which the payment request expires.
+	ExpiresAt time.Time
 
 	// Description is a description attached to the payment request.
 	Description string
@@ -2963,7 +2963,7 @@ func (s *lightningClient) DecodePaymentRequest(ctx context.Context,
 	if resp.Expiry != 0 {
 		// LND reports expiry as a duration from the invoice timestamp.
 		invoiceTimestamp := time.Unix(resp.Timestamp, 0)
-		paymentReq.Expiry = invoiceTimestamp.Add(
+		paymentReq.ExpiresAt = invoiceTimestamp.Add(
 			time.Duration(resp.Expiry) * time.Second,
 		)
 	}

--- a/lightning_client.go
+++ b/lightning_client.go
@@ -2961,7 +2961,11 @@ func (s *lightningClient) DecodePaymentRequest(ctx context.Context,
 	}
 
 	if resp.Expiry != 0 {
-		paymentReq.Expiry = time.Unix(resp.Expiry, 0)
+		// LND reports expiry as a duration from the invoice timestamp.
+		invoiceTimestamp := time.Unix(resp.Timestamp, 0)
+		paymentReq.Expiry = invoiceTimestamp.Add(
+			time.Duration(resp.Expiry) * time.Second,
+		)
 	}
 
 	return paymentReq, nil

--- a/lightning_client_test.go
+++ b/lightning_client_test.go
@@ -37,9 +37,9 @@ func (m *mockDecodePayReqRPCClient) DecodePayReq(_ context.Context,
 	return m.response, nil
 }
 
-// TestLightningClientDecodePaymentRequestExpiry ensures that the relative
+// TestLightningClientDecodePaymentRequestExpiresAt ensures that the relative
 // expiry returned by lnd is converted to an absolute expiration time.
-func TestLightningClientDecodePaymentRequestExpiry(t *testing.T) {
+func TestLightningClientDecodePaymentRequestExpiresAt(t *testing.T) {
 	t.Parallel()
 
 	timestamp := time.Unix(1_700_000_000, 0)
@@ -65,7 +65,7 @@ func TestLightningClientDecodePaymentRequestExpiry(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, encoded, mock.request.PayReq)
 	require.Equal(t, timestamp, request.Timestamp)
-	require.Equal(t, timestamp.Add(expiry), request.Expiry)
+	require.Equal(t, timestamp.Add(expiry), request.ExpiresAt)
 }
 
 // mockRPCClient implements lnrpc.LightningClient with dynamic method

--- a/lightning_client_test.go
+++ b/lightning_client_test.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/invoicesrpc"
 	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/lightningnetwork/lnd/routing/route"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 )
@@ -17,6 +19,53 @@ import (
 type addInvoiceArg struct {
 	in   *lnrpc.Invoice
 	opts []grpc.CallOption
+}
+
+type mockDecodePayReqRPCClient struct {
+	lnrpc.LightningClient
+
+	request  *lnrpc.PayReqString
+	response *lnrpc.PayReq
+}
+
+func (m *mockDecodePayReqRPCClient) DecodePayReq(_ context.Context,
+	request *lnrpc.PayReqString, _ ...grpc.CallOption) (*lnrpc.PayReq,
+	error) {
+
+	m.request = request
+
+	return m.response, nil
+}
+
+// TestLightningClientDecodePaymentRequestExpiry ensures that the relative
+// expiry returned by lnd is converted to an absolute expiration time.
+func TestLightningClientDecodePaymentRequestExpiry(t *testing.T) {
+	t.Parallel()
+
+	timestamp := time.Unix(1_700_000_000, 0)
+	expiry := 90 * time.Minute
+	paymentHash := lntypes.Hash{1, 2, 3}
+	destination := route.Vertex{2}
+	encoded := "test invoice"
+
+	mock := &mockDecodePayReqRPCClient{
+		response: &lnrpc.PayReq{
+			Destination: destination.String(),
+			PaymentHash: paymentHash.String(),
+			Timestamp:   timestamp.Unix(),
+			Expiry:      int64(expiry.Seconds()),
+		},
+	}
+	client := &lightningClient{
+		client:  mock,
+		timeout: time.Second,
+	}
+
+	request, err := client.DecodePaymentRequest(t.Context(), encoded)
+	require.NoError(t, err)
+	require.Equal(t, encoded, mock.request.PayReq)
+	require.Equal(t, timestamp, request.Timestamp)
+	require.Equal(t, timestamp.Add(expiry), request.Expiry)
 }
 
 // mockRPCClient implements lnrpc.LightningClient with dynamic method


### PR DESCRIPTION
LND returns DecodePayReq expiry as a duration from the invoice timestamp. Add that duration instead of treating it as an absolute Unix timestamp.

See https://github.com/lightningnetwork/lnd/pull/11058

Also renamed `PaymentRequest.Expiry` to `PaymentRequest.ExpiresAt` to prevent existing callers from silently interpreting the changed value semantics. **This is a breaking API change!**


#### Pull Request Checklist

- [ ] PR is opened against correct version branch.
- [ ] Version compatibility matrix in the README and minimal required version
      in `lnd_services.go` are updated.
- [ ] Update `macaroon_recipes.go` if your PR adds a new method that is called
  differently than the RPC method it invokes.
