### PR TITLE
routerrpc: support invoice payment components

### DIFF
--- a/router_client.go
+++ b/router_client.go
@@ -571,7 +571,9 @@ func (r *routerClient) SendPayment(ctx context.Context,
 		rpcReq.Dest = request.Target[:]
 		rpcReq.Amt = int64(request.Amount)
 		rpcReq.AmtMsat = int64(request.AmountMsat)
-		rpcReq.PaymentHash = request.PaymentHash[:]
+		if request.PaymentHash != nil {
+			rpcReq.PaymentHash = request.PaymentHash[:]
+		}
 		if request.PaymentAddr != nil {
 			rpcReq.PaymentAddr = request.PaymentAddr[:]
 		}

--- a/router_client.go
+++ b/router_client.go
@@ -245,8 +245,9 @@ func NewHtlcFailure(rpcFailure *lnrpc.Failure) *HtlcFailure {
 // SendPaymentRequest defines the payment parameters for a new payment.
 type SendPaymentRequest struct {
 	// Invoice is an encoded payment request. The individual payment
-	// parameters Target, Amount, PaymentHash, FinalCLTVDelta and RouteHints
-	// are only processed when the Invoice field is empty.
+	// parameters Target, Amount, AmountMsat, PaymentHash, PaymentAddr,
+	// FinalCLTVDelta, RouteHints and DestFeatures are only processed when
+	// the Invoice field is empty.
 	Invoice string
 
 	// MaxFee is the fee limit for this payment.
@@ -272,12 +273,20 @@ type SendPaymentRequest struct {
 	Target route.Vertex
 
 	// Amount is the value of the payment to send through the network in
-	// satoshis.
+	// satoshis. Amount and AmountMsat are mutually exclusive.
 	Amount btcutil.Amount
+
+	// AmountMsat is the value of the payment to send through the network in
+	// millisatoshis. Amount and AmountMsat are mutually exclusive.
+	AmountMsat lnwire.MilliSatoshi
 
 	// PaymentHash is the r-hash value to use within the HTLC extended to
 	// the first hop.
 	PaymentHash *lntypes.Hash
+
+	// PaymentAddr is the payment address to use for the payment. If nil, no
+	// payment address is used.
+	PaymentAddr *[32]byte
 
 	// FinalCLTVDelta is the CTLV expiry delta to use for the _final_ hop
 	// in the route. This means that the final hop will have a CLTV delta
@@ -293,6 +302,10 @@ type SendPaymentRequest struct {
 	// together and sorted in forward order in order to reach the
 	// destination successfully.
 	RouteHints [][]zpay32.HopHint
+
+	// DestFeatures contains the feature bits advertised by the payment
+	// destination.
+	DestFeatures []lnrpc.FeatureBit
 
 	// LastHopPubkey is the pubkey of the last hop of the route taken
 	// for this payment. If empty, any hop may be used.
@@ -557,8 +570,13 @@ func (r *routerClient) SendPayment(ctx context.Context,
 	if request.Invoice == "" {
 		rpcReq.Dest = request.Target[:]
 		rpcReq.Amt = int64(request.Amount)
+		rpcReq.AmtMsat = int64(request.AmountMsat)
 		rpcReq.PaymentHash = request.PaymentHash[:]
+		if request.PaymentAddr != nil {
+			rpcReq.PaymentAddr = request.PaymentAddr[:]
+		}
 		rpcReq.FinalCltvDelta = int32(request.FinalCLTVDelta)
+		rpcReq.DestFeatures = request.DestFeatures
 
 		routeHints, err := marshallRouteHints(request.RouteHints)
 		if err != nil {

--- a/router_client_test.go
+++ b/router_client_test.go
@@ -2,19 +2,21 @@ package lndclient
 
 import (
 	"context"
+	"io"
 	"testing"
 	"time"
 
 	"github.com/btcsuite/btcd/btcutil/v2"
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/routerrpc"
+	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/routing/route"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 )
 
-type mockRouterRPCClient struct {
+type mockRouteFeeRPCClient struct {
 	routerrpc.RouterClient
 
 	request  *routerrpc.RouteFeeRequest
@@ -22,11 +24,12 @@ type mockRouterRPCClient struct {
 	err      error
 }
 
-func (m *mockRouterRPCClient) EstimateRouteFee(_ context.Context,
+func (m *mockRouteFeeRPCClient) EstimateRouteFee(_ context.Context,
 	request *routerrpc.RouteFeeRequest, _ ...grpc.CallOption) (
 	*routerrpc.RouteFeeResponse, error) {
 
 	m.request = request
+
 	return m.response, m.err
 }
 
@@ -35,7 +38,7 @@ func (m *mockRouterRPCClient) EstimateRouteFee(_ context.Context,
 func TestEstimateRouteFeeWithProbe(t *testing.T) {
 	t.Parallel()
 
-	mock := &mockRouterRPCClient{
+	mock := &mockRouteFeeRPCClient{
 		response: &routerrpc.RouteFeeResponse{
 			RoutingFeeMsat: 987,
 			TimeLockDelay:  654,
@@ -69,7 +72,7 @@ func TestEstimateRouteFee(t *testing.T) {
 	t.Parallel()
 
 	dest := testVertex()
-	mock := &mockRouterRPCClient{
+	mock := &mockRouteFeeRPCClient{
 		response: &routerrpc.RouteFeeResponse{
 			RoutingFeeMsat: 4321,
 		},
@@ -113,7 +116,7 @@ func TestEstimateRouteFeeWithProbeRejectsInvalidTimeout(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			mock := &mockRouterRPCClient{}
+			mock := &mockRouteFeeRPCClient{}
 			client := &routerClient{
 				client: mock,
 			}
@@ -125,6 +128,70 @@ func TestEstimateRouteFeeWithProbeRejectsInvalidTimeout(t *testing.T) {
 			require.Nil(t, mock.request)
 		})
 	}
+}
+
+type mockSendPaymentRPCClient struct {
+	routerrpc.RouterClient
+
+	request *routerrpc.SendPaymentRequest
+}
+
+func (m *mockSendPaymentRPCClient) SendPaymentV2(_ context.Context,
+	request *routerrpc.SendPaymentRequest, _ ...grpc.CallOption) (
+	routerrpc.Router_SendPaymentV2Client, error) {
+
+	m.request = request
+
+	return &mockSendPaymentStream{}, nil
+}
+
+type mockSendPaymentStream struct {
+	routerrpc.Router_SendPaymentV2Client
+}
+
+func (m *mockSendPaymentStream) Recv() (*lnrpc.Payment, error) {
+	return nil, io.EOF
+}
+
+// TestSendPaymentComponents checks that all invoice component fields are
+// forwarded to lnd without an encoded payment request.
+func TestSendPaymentComponents(t *testing.T) {
+	t.Parallel()
+
+	target := testVertex()
+	paymentHash := lntypes.Hash{1, 2, 3}
+	paymentAddr := [32]byte{4, 5, 6}
+	destFeatures := []lnrpc.FeatureBit{
+		lnrpc.FeatureBit_TLV_ONION_REQ,
+		lnrpc.FeatureBit_PAYMENT_ADDR_REQ,
+		lnrpc.FeatureBit_MPP_OPT,
+	}
+
+	mock := &mockSendPaymentRPCClient{}
+	client := &routerClient{
+		client: mock,
+	}
+
+	_, _, err := client.SendPayment(
+		t.Context(), SendPaymentRequest{
+			Target:         target,
+			AmountMsat:     123456,
+			PaymentHash:    &paymentHash,
+			PaymentAddr:    &paymentAddr,
+			FinalCLTVDelta: 144,
+			DestFeatures:   destFeatures,
+		},
+	)
+	require.NoError(t, err)
+
+	require.Empty(t, mock.request.PaymentRequest)
+	require.Equal(t, target[:], mock.request.Dest)
+	require.Zero(t, mock.request.Amt)
+	require.Equal(t, int64(123456), mock.request.AmtMsat)
+	require.Equal(t, paymentHash[:], mock.request.PaymentHash)
+	require.Equal(t, paymentAddr[:], mock.request.PaymentAddr)
+	require.Equal(t, int32(144), mock.request.FinalCltvDelta)
+	require.Equal(t, destFeatures, mock.request.DestFeatures)
 }
 
 func testVertex() route.Vertex {

--- a/router_client_test.go
+++ b/router_client_test.go
@@ -194,6 +194,29 @@ func TestSendPaymentComponents(t *testing.T) {
 	require.Equal(t, destFeatures, mock.request.DestFeatures)
 }
 
+// TestSendPaymentAMPComponents checks that AMP component payments can omit a
+// payment hash for lnd to generate the AMP payment identifiers.
+func TestSendPaymentAMPComponents(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockSendPaymentRPCClient{}
+	client := &routerClient{
+		client: mock,
+	}
+
+	_, _, err := client.SendPayment(
+		t.Context(), SendPaymentRequest{
+			Target:     testVertex(),
+			AmountMsat: 123456,
+			AMP:        true,
+		},
+	)
+	require.NoError(t, err)
+
+	require.True(t, mock.request.Amp)
+	require.Empty(t, mock.request.PaymentHash)
+}
+
 func testVertex() route.Vertex {
 	var vertex route.Vertex
 	for i := range vertex {

--- a/router_client_test.go
+++ b/router_client_test.go
@@ -6,12 +6,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil/v2"
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/routerrpc"
 	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/routing/route"
+	"github.com/lightningnetwork/lnd/zpay32"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 )
@@ -161,6 +163,14 @@ func TestSendPaymentComponents(t *testing.T) {
 	target := testVertex()
 	paymentHash := lntypes.Hash{1, 2, 3}
 	paymentAddr := [32]byte{4, 5, 6}
+	_, hintNode := btcec.PrivKeyFromBytes([]byte{7, 8, 9})
+	routeHints := [][]zpay32.HopHint{{{
+		NodeID:                    hintNode,
+		ChannelID:                 123,
+		FeeBaseMSat:               456,
+		FeeProportionalMillionths: 789,
+		CLTVExpiryDelta:           40,
+	}}}
 	destFeatures := []lnrpc.FeatureBit{
 		lnrpc.FeatureBit_TLV_ONION_REQ,
 		lnrpc.FeatureBit_PAYMENT_ADDR_REQ,
@@ -179,6 +189,7 @@ func TestSendPaymentComponents(t *testing.T) {
 			PaymentHash:    &paymentHash,
 			PaymentAddr:    &paymentAddr,
 			FinalCLTVDelta: 144,
+			RouteHints:     routeHints,
 			DestFeatures:   destFeatures,
 		},
 	)
@@ -191,6 +202,15 @@ func TestSendPaymentComponents(t *testing.T) {
 	require.Equal(t, paymentHash[:], mock.request.PaymentHash)
 	require.Equal(t, paymentAddr[:], mock.request.PaymentAddr)
 	require.Equal(t, int32(144), mock.request.FinalCltvDelta)
+	require.Equal(t, []*lnrpc.RouteHint{{
+		HopHints: []*lnrpc.HopHint{{
+			NodeId:                    route.NewVertex(hintNode).String(),
+			ChanId:                    123,
+			FeeBaseMsat:               456,
+			FeeProportionalMillionths: 789,
+			CltvExpiryDelta:           40,
+		}},
+	}}, mock.request.RouteHints)
 	require.Equal(t, destFeatures, mock.request.DestFeatures)
 }
 


### PR DESCRIPTION
Add missing parts to pay invoices via payment components.

#### Pull Request Checklist

- [ ] PR is opened against correct version branch.
- [ ] Version compatibility matrix in the README and minimal required version
      in `lnd_services.go` are updated.
- [ ] Update `macaroon_recipes.go` if your PR adds a new method that is called
  differently than the RPC method it invokes.
