### PR TITLE
lndclient: add AutoFailHeight to InterceptedHtlc

### DIFF
--- a/router_client.go
+++ b/router_client.go
@@ -386,6 +386,14 @@ type InterceptedHtlc struct {
 	// InWireCustomRecords are custom records sent by the sender that were
 	// only present in the wire message and not the onion itself.
 	InWireCustomRecords map[uint64][]byte
+
+	// AutoFailHeight is the block height at which lnd will auto-fail this
+	// held htlc to keep the channel from force-closing. It is earlier than
+	// IncomingExpiryHeight by lnd's FinalCltvRejectDelta and is the real
+	// deadline for work against a held htlc. A zero value means unknown
+	// (for example an older lnd that predates the field) and should be
+	// treated conservatively, not as a literal height of 0.
+	AutoFailHeight int32
 }
 
 // HtlcInterceptHandler is a function signature for handling code for htlc
@@ -1071,6 +1079,7 @@ func (r *routerClient) InterceptHtlcs(ctx context.Context,
 				CustomRecords:        request.CustomRecords,
 				OnionBlob:            request.OnionBlob,
 				InWireCustomRecords:  inWireCustomRecords,
+				AutoFailHeight:       request.AutoFailHeight,
 			}
 
 			// Try to send our interception request, failing on


### PR DESCRIPTION

## Description

**_lnd_** sends `auto_fail_height` on every intercepted HTLC, the height at which it will auto-fail the held HTLC to keep the channel from force-closing, but **_lndclient_** dropped it. This adds `AutoFailHeight` to `InterceptedHtlc`
and passes the field through.

It is the real deadline for work against a held HTLC: earlier than `IncomingExpiryHeight` by `FinalCltvRejectDelta`, so callers reasoning against `IncomingExpiryHeight` think they have more runway than they do.

#### Pull Request Checklist
- [ ] PR is opened against correct version branch.
- [ ] Version compatibility matrix in the README and minimal required version
      in `lnd_services.go` are updated.
- [ ] Update `macaroon_recipes.go` if your PR adds a new method that is called
  differently than the RPC method it invokes.